### PR TITLE
Add Obsoletes: modules-tcl to environment-modules.spec

### DIFF
--- a/contrib/rpm/environment-modules.spec
+++ b/contrib/rpm/environment-modules.spec
@@ -42,6 +42,7 @@ Provides:       environment(modules)
 %else
 Provides:       environment-modules
 %endif
+Obsoletes:      modules-tcl
 
 %description
 The Environment Modules package provides for the dynamic modification of


### PR DESCRIPTION
contrib/rpm/environment-modules.spec: Now Obsoletes: modules-tcl. Results in modules-tcl being removed by yum when environment-modules is installed.