### PR TITLE
added set-function and unset-function commands

### DIFF
--- a/modulecmd.tcl.in
+++ b/modulecmd.tcl.in
@@ -655,9 +655,11 @@ prepend-path   {prepend-path   remove-path    prepend-path   prepend-path   prep
 prereq         {prereq         nop            reportCmd      nop            nop            nop           }
 remove-path    {remove-path    remove-path-un remove-path    remove-path    remove-path    edit-path-wh  }
 set-alias      {set-alias      set-alias-un   reportCmd      nop            nop            nop           }
+set-function   {set-function   set-function-un reportCmd     nop            nop            nop           }
 setenv         {setenv         setenv-un      setenv         setenv         setenv         setenv-wh     }
 system         {system         system         reportCmd      nop            nop            nop           }
 unset-alias    {unset-alias    nop            reportCmd      nop            nop            nop           }
+unset-function {unset-function nop            reportCmd      nop            nop            nop           }
 unsetenv       {unsetenv       unsetenv-un    unsetenv       unsetenv       unsetenv       setenv-wh     }
 x-resource     {x-resource     x-resource     reportCmd      nop            nop            nop           }
       }
@@ -2365,6 +2367,30 @@ proc unset-alias {alias} {
    return {}
 }
 
+proc set-function {function what} {
+   reportDebug "function='$function', val='$what'"
+
+   set ::g_Functions($function) $what
+   set ::g_stateFunctions($function) "new"
+
+   return {}
+}
+
+# undo set-function in unload mode
+proc set-function-un {function what} {
+   return [unset-function $function]
+}
+
+proc unset-function {function} {
+   reportDebug "function='$function'"
+
+   set ::g_Functions($function) {}
+   set ::g_stateFunctions($function) "del"
+
+   return {}
+}
+
+
 proc is-loaded {args} {
    reportDebug "$args"
 
@@ -3806,7 +3832,7 @@ proc runModulerc {} {
 # for each module loaded or unloaded in order to be able to restore the
 # correct set in case of failure
 proc pushSettings {} {
-   foreach var {env g_clearedEnvVars g_Aliases g_stateEnvVars g_stateAliases\
+   foreach var {env g_clearedEnvVars g_Aliases g_stateEnvVars g_stateAliases g_stateFunctions g_Functions\
       g_newXResources g_delXResources} {
       eval "lappend ::g_SAVE_$var \[array get ::$var\]"
    }
@@ -3821,7 +3847,7 @@ proc pushSettings {} {
 }
 
 proc popSettings {} {
-   foreach var {env g_clearedEnvVars g_Aliases g_stateEnvVars g_stateAliases\
+   foreach var {env g_clearedEnvVars g_Aliases g_stateEnvVars g_stateAliases g_stateFunctions g_Functions\
       g_newXResources g_delXResources g_changeDir g_stdoutPuts\
       g_return_text} {
       eval "set ::g_SAVE_$var \[lrange \$::g_SAVE_$var 0 end-1\]"
@@ -3829,7 +3855,7 @@ proc popSettings {} {
 }
 
 proc restoreSettings {} {
-   foreach var {env g_clearedEnvVars g_Aliases g_stateEnvVars g_stateAliases\
+   foreach var {env g_clearedEnvVars g_Aliases g_stateEnvVars g_stateAliases g_stateFunctions g_Functions\
       g_newXResources g_delXResources} {
       # clear current $var arrays
       if {[info exists ::$var]} {
@@ -3850,16 +3876,17 @@ proc restoreSettings {} {
 }
 
 proc renderSettings {} {
-   global g_stateEnvVars g_stateAliases g_newXResources g_delXResources
+   global g_stateEnvVars g_stateAliases g_stateFunctions g_newXResources g_delXResources
 
    reportDebug "called."
 
-   # required to work on ygwin, shouldn't hurt real linux
+   # required to work on cygwin, shouldn't hurt real linux
    fconfigure stdout -translation lf
 
    # preliminaries if there is stuff to render
    if {$::g_autoInit || [array size g_stateEnvVars] > 0 ||\
       [array size g_stateAliases] > 0 || [array size g_newXResources] > 0 ||\
+      [array size g_stateFunctions] > 0 ||\
       [array size g_delXResources] > 0 || [info exists ::g_changeDir] ||\
       [info exists ::g_stdoutPuts] || [info exists ::g_return_text]} {
       switch -- $::g_shellType {
@@ -4031,6 +4058,33 @@ proc renderSettings {} {
                }
                {cmd} {
                   puts stdout "doskey $var="
+               }
+            }
+         }
+      }
+   }
+   foreach funcname [array names g_stateFunctions] {
+      switch -- $g_stateFunctions($funcname) {
+         {new} {
+            set val $::g_Functions($funcname)
+            switch -- $::g_shellType {
+               {sh} {
+                  #set val [charEscaped $val]
+		  puts stdout "$funcname () { $val ;} ; export $funcname;"
+               }
+               {fish} {
+                  #set val [charEscaped $val]
+		  puts stdout "function $funcname ; $val ; end ;"
+               }
+            }
+         }
+         {del} {
+            switch -- $::g_shellType {
+               {sh} {
+                  puts stdout "unset -f $funcname;"
+               }
+               {fish} {
+                  puts stdout "functions -e $funcname;"
                }
             }
          }


### PR DESCRIPTION
I've added the `set-function` and `unset-function` commands and tested them locally using sh type shells and fish.  I have not found documentation on how to export a function in fish, it is unclear if that is possible.

I am not a fish user, but one thing I have noticed is that fish syntax is significantly different from sh type shells and not compatible.  Thus any functions that use command-substitution or function arguments will be need to be different.  To support both using the same set-function command may involve duplicate definitions, e.g.:
```tcl
if { [module-info shelltype sh] } then {
    set-function mycd {eval `mycd.sh $1`}
} elseif { [module-info shelltype fish] } then {
    set-function mycd {eval (mycd.sh $argv[1])}
}
```
In this case, it might be useful to define helper functions so that it is more seamless, e.g:

```tcl
## Shell helper function
## Accepts either a number or "all", for all arguments.
proc shell-arg {argnum} {
    if { [module-info shelltype fish] } then {
	if { $argnum == "all" } then {
	    return "\$argv"
	} else {
	    return "\$argv\[${argnum}\]"
	}
    } else {
	if { $argnum == "all" } then {
	    return "\"\$@\""
	} else {
	    return "\$${argnum}"
	}
    }
}

## Shell helper function
## Wraps a command with the appropriate command substitution
## delimiters.  Either:
##  (cmd)  ==> for fish
##  `cmd`  ==> for all other shells
proc shell-commandsub {args} {
    if { [module-info shelltype fish] } then {
	return "([join $args])"
    }
    return "\`[join $args]\`"
}
    
set-function mycd "eval [shell-commandsub mycd.sh [shell-arg 1]]"
```

I'm not sure if it would be best to let users handle this, or add these `shell-arg` and `shell-commandsub` convenience procedures to the modulecmd.tcl - **please advise**.  Supporting these helper procs within modules may open up the door to additional feature requests.

No tests for set-function / unset-function, will wait on feedback.
