### PR TITLE
Fix hanging 'list' command

### DIFF
--- a/modulecmd.tcl.in
+++ b/modulecmd.tcl.in
@@ -6312,7 +6312,7 @@ proc displayElementList {header hstyle one_per_line display_idx args} {
       set tty_cols [getTtyColumns]
       # find valid grid by starting with non-optimized solution where each
       # column length is equal to the length of the biggest element to display
-      set cur_cols [expr {int($tty_cols / $max_len)}]
+      set cur_cols [expr {int(($tty_cols - $elt_prefix_len) / $max_len)}]
       # when display is found too short to display even one column
       if {$cur_cols == 0} {
          set cols 1

--- a/testsuite/modules.70-maint/040-list.exp
+++ b/testsuite/modules.70-maint/040-list.exp
@@ -101,10 +101,44 @@ setenv_loaded_module [list foo bar] "/path/to/foo"
 testouterr_cmd_re "sh" "list" "ERR" "$err_loinconsist\n  LOADEDMODULES=foo bar\n  _LMFILES_=/path/to/foo"
 
 #
+# test specific terminal width when one loaded module name fill whole width
+#
+
+set module loc_dv1/1.0
+setenv_loaded_module $module $modpath/$module
+
+set test_cols 16
+if {![info exists term_cols]} {
+    # skip tests if current terminal witdh is unknown
+    send_user "\tskipping terminal width-specific tests\n"
+# set a specific terminal width
+} elseif {[catch {exec stty cols $test_cols}] || [getTtyCols] ne $test_cols} {
+    send_user "\tskipping terminal width-specific tests, cannot set width\n"
+} else {
+
+testouterr_cmd sh list OK "$header\n 1) $module  "
+
+# test with slightly bigger width
+exec stty cols 17
+testouterr_cmd sh list OK "$header\n 1) $module  "
+
+# test with slightly smaller width
+exec stty cols 15
+testouterr_cmd sh list OK "$header\n 1) $module  "
+
+# restore terminal width
+exec stty cols $term_cols
+
+}
+
+
+#
 #  Cleanup
 #
 
 unsetenv_loaded_module
+
+unset test_cols
 
 unset ts_csh
 unset ts_csh_num


### PR DESCRIPTION
Bug correction of the list command for the case when
the terminal width is equal to the text width to be printed
when only a single column is used.

Without the correction, the 'moudule list' command hangs.