### PR TITLE
Use quote instead of code for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,23 +150,23 @@ Links
 
 Web site:
 
-    http://modules.sourceforge.net
+> http://modules.sourceforge.net
 
 Online documentation:
 
-    https://modules.readthedocs.io
+> https://modules.readthedocs.io
 
 GitHub source respository:
 
-    https://github.com/cea-hpc/modules
+> https://github.com/cea-hpc/modules
 
 GitHub Issue tracking system:
 
-    https://github.com/cea-hpc/modules/issues
+> https://github.com/cea-hpc/modules/issues
 
 SourceForge project page:
 
-    http://sourceforge.net/projects/modules/
+> http://sourceforge.net/projects/modules/
 
 
 Authors


### PR DESCRIPTION
Inside a code block URLs are not converted to links when the Markdown is rendered as HTML. In a quote they do. The other differences are minor both for the raw text and for the rendered text.