### PR TITLE
Add hyperlinks to docs via semantic markup.

### DIFF
--- a/doc/example/modulepaths-persist-over-sudo/rc
+++ b/doc/example/modulepaths-persist-over-sudo/rc
@@ -4,10 +4,10 @@
 # to initialize it if not defined
 if {![is-used] && [file readable /usr/share/Modules/init/.modulespath]} {
     set fid [open /usr/share/Modules/init/.modulespath r]
-    set fdata [split [read $fid] \n]
+    set fdata [split [read $fid] "\n"]
     close $fid
     foreach fline $fdata {
-        if {[regexp {^\s*(.*?)\s*(#.*|)$} $fline match patharg] == 1\
+        if {[regexp "^\\s*(.*?)\\s*(#.*|)\$" $fline match patharg] == 1
             && $patharg ne {}} {
             eval module use --append [split $patharg :]
         }

--- a/doc/example/test-modulefiles/modulefiles/test_dir_and_file
+++ b/doc/example/test-modulefiles/modulefiles/test_dir_and_file
@@ -32,7 +32,7 @@ proc ModulesTest { } {
     }
     puts stderr "Running ModulesTest for file creation...done"
 
-    return ${retcode}
+    return $retcode
 }
 
 setenv TESTDIR  /tmp/$::env(USER)/testdir

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -197,21 +197,29 @@ rst_epilog = '\n'
 rst_epilog += '.. |prefix| replace:: %s\n' % prefix
 rst_epilog += '.. |emph prefix| replace:: *%s*\n' % prefix
 rst_epilog += '.. |bold prefix| replace:: **%s**\n' % prefix
+rst_epilog += '.. |file prefix| replace:: :file:`%s`\n' % prefix
 rst_epilog += '.. |bindir| replace:: %s\n' % bindir
 rst_epilog += '.. |emph bindir| replace:: *%s*\n' % bindir
 rst_epilog += '.. |bold bindir| replace:: **%s**\n' % bindir
 rst_epilog += '.. |libexecdir| replace:: %s\n' % libexecdir
 rst_epilog += '.. |emph libexecdir| replace:: *%s*\n' % libexecdir
 rst_epilog += '.. |bold libexecdir| replace:: **%s**\n' % libexecdir
+rst_epilog += '.. |file libexecdir| replace:: :file:`%s`\n' % libexecdir
+rst_epilog += '.. |file libexecdir_modulecmd| replace:: :file:`%s/modulecmd.tcl`\n' % libexecdir
 rst_epilog += '.. |etcdir| replace:: %s\n' % etcdir
 rst_epilog += '.. |emph etcdir| replace:: *%s*\n' % etcdir
 rst_epilog += '.. |bold etcdir| replace:: **%s**\n' % etcdir
+rst_epilog += '.. |file etcdir_rc| replace:: :file:`%s/rc`\n' % etcdir
+rst_epilog += '.. |file etcdir_siteconfig| replace:: :file:`%s/siteconfig.tcl`\n' % etcdir
 rst_epilog += '.. |initdir| replace:: %s\n' % initdir
 rst_epilog += '.. |emph initdir| replace:: *%s*\n' % initdir
 rst_epilog += '.. |bold initdir| replace:: **%s**\n' % initdir
+rst_epilog += '.. |file initdir_shell| replace:: :file:`%s/<shell>`\n' % initdir
+rst_epilog += '.. |file initdir_csh| replace:: :file:`%s/csh`\n' % initdir
 rst_epilog += '.. |modulefilesdir| replace:: %s\n' % modulefilesdir
 rst_epilog += '.. |emph modulefilesdir| replace:: *%s*\n' % modulefilesdir
 rst_epilog += '.. |bold modulefilesdir| replace:: **%s**\n' % modulefilesdir
+rst_epilog += '.. |file modulefilesdir| replace:: :file:`%s`\n' % modulefilesdir
 
 
 # -- Options for manual page output ---------------------------------------

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -239,3 +239,31 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
 ]
+
+
+# -- Extension interface --------------------------------------------------
+
+from sphinx import addnodes
+def parse_cmd_args_node(env, sig, signode):
+    try:
+        cmd, args = sig.strip().split(' ', 1)
+    except ValueError:
+        cmd, args = sig, None
+    # distinguish cmd from its args
+    signode += addnodes.desc_name(cmd, cmd)
+    if args:
+        args = ' ' + args
+        signode += addnodes.desc_addname(args, args)
+    return cmd
+
+# define new directive/role that can be used as .. subcmd::/:subcmd: and
+# .. mfcmd::/:mfcmd:
+def setup(app):
+    app.add_object_type('subcmd', 'subcmd',
+                        objname='module sub-command',
+                        indextemplate='pair: %s; module sub-command',
+                        parse_node=parse_cmd_args_node)
+    app.add_object_type(directivename='mfcmd', rolename='mfcmd',
+                        objname='modulefile command',
+                        indextemplate='%s (modulefile command)',
+                        parse_node=parse_cmd_args_node)

--- a/doc/source/cookbook/ensure-user-qualify-modules.rst
+++ b/doc/source/cookbook/ensure-user-qualify-modules.rst
@@ -37,6 +37,7 @@ configuration directory (or in the ``modulerc`` file installed in the
 initialization script directory if this location is preferred).
 
 .. literalinclude:: ../../example/ensure-user-qualify-modules/initrc
+   :language: tcl
    :caption: initrc
 
 It may be desired to lock this option, to ensure users do not alter it
@@ -46,6 +47,7 @@ configuration script, users will not be able to change the
 ``implicit_default`` behavior you configure.
 
 .. literalinclude:: ../../example/ensure-user-qualify-modules/siteconfig.tcl
+   :language: tcl
    :caption: siteconfig.tcl
    :lines: 13-17
 

--- a/doc/source/cookbook/inhibit-report-info.rst
+++ b/doc/source/cookbook/inhibit-report-info.rst
@@ -22,6 +22,7 @@ For v4.2 versions, a site-specific configuration script is proposed to inhibit
 the output of the info-level messages.
 
 .. literalinclude:: ../../example/inhibit-report-info/siteconfig.tcl
+   :language: tcl
    :caption: siteconfig.tcl
    :lines: 14-23
 

--- a/doc/source/cookbook/log-module-commands.rst
+++ b/doc/source/cookbook/log-module-commands.rst
@@ -18,6 +18,7 @@ prior processing the module command itself. The log message sent describes the
 module command called and who called it.
 
 .. literalinclude:: ../../example/log-module-commands/siteconfig.tcl
+   :language: tcl
    :caption: siteconfig.tcl
    :lines: 13-20
 

--- a/doc/source/cookbook/module-info-name-return-basename.rst
+++ b/doc/source/cookbook/module-info-name-return-basename.rst
@@ -20,6 +20,7 @@ that supersedes the definition of the ``module-info name`` command to return
 modulefile basename instead of full pathname.
 
 .. literalinclude:: ../../example/module-info-name-return-basename/siteconfig.tcl
+   :language: tcl
    :caption: siteconfig.tcl
    :lines: 13-27
 

--- a/doc/source/cookbook/modulepaths-persist-over-sudo.rst
+++ b/doc/source/cookbook/modulepaths-persist-over-sudo.rst
@@ -25,6 +25,7 @@ can be parsed to enable on the fly the default modulepaths (with ``module
 use`` Tcl modulefile command).
 
 .. literalinclude:: ../../example/modulepaths-persist-over-sudo/rc
+   :language: tcl
    :caption: Global RC file
 
 **Compatible with Modules v4.1+**

--- a/doc/source/cookbook/test-modulefiles.rst
+++ b/doc/source/cookbook/test-modulefiles.rst
@@ -13,6 +13,7 @@ Code
 ----
 
 .. literalinclude:: ../../example/test-modulefiles/modulefiles/test_dir_and_file
+   :language: tcl
    :caption: test_dir_and_file
 
 

--- a/doc/source/cookbook/unload-firstly-loaded.rst
+++ b/doc/source/cookbook/unload-firstly-loaded.rst
@@ -21,6 +21,7 @@ For older v4 versions, a site-specific configuration script is proposed to
 select firstly loaded module matching name rather lastly loaded.
 
 .. literalinclude:: ../../example/unload-firstly-loaded/siteconfig.tcl
+   :language: tcl
    :caption: siteconfig.tcl
    :lines: 15-20
 

--- a/doc/source/diff_v3_v4.rst
+++ b/doc/source/diff_v3_v4.rst
@@ -499,7 +499,7 @@ Modules Specific Tcl Commands
 
 **is-loaded**
 
- Starting with version ``4.1``, **is-loaded** supports being called with no argument passed. In this case, it returns *true* if any modulefile is currently loaded, *false* elsewhere.
+ Starting with version ``4.1``, **is-loaded** supports being called with no argument passed. In this case, it returns *true* if any modulefile is currently loaded, *false* otherwise.
 
  Starting with version ``4.2``, **is-loaded** supports being called with a symbolic modulefile or a modulefile alias passed as argument.
 

--- a/doc/source/diff_v3_v4.rst
+++ b/doc/source/diff_v3_v4.rst
@@ -393,6 +393,8 @@ Modules collections are not supported on compatibility version.
 Environment
 ^^^^^^^^^^^
 
+**MODULECONTACT**
+
 **MODULES_COLLECTION_TARGET**
 
 **MODULES_USE_COMPAT_VERSION**

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -883,23 +883,16 @@ The :command:`module` command exits with **0** if its execution succeed. Otherwi
 ENVIRONMENT
 -----------
 
-.. _LOADEDMODULES:
-
-
-**LOADEDMODULES**
+.. envvar:: LOADEDMODULES
 
  A colon separated list of all loaded *modulefiles*.
 
-.. _MODULECONTACT:
-
-**MODULECONTACT**
+.. envvar:: MODULECONTACT
 
  Email address to contact in case any issue occurs during the interpretation
  of modulefiles.
 
-.. _MODULEPATH:
-
-**MODULEPATH**
+.. envvar:: MODULEPATH
 
  The path that the :command:`module` command searches when looking for
  *modulefiles*. Typically, it is set to the master *modulefiles* directory,
@@ -914,24 +907,18 @@ ENVIRONMENT
  **MODULEPATH** value. If an environment variable referred in a path element
  is not defined, its reference is converted to an empty string.
 
-.. _MODULERCFILE:
-
-**MODULERCFILE**
+.. envvar:: MODULERCFILE
 
  The location of a global run-command file containing *modulefile* specific
  setup. See `Modulecmd startup`_ section for detailed information.
 
-.. _MODULESHOME:
-
-**MODULESHOME**
+.. envvar:: MODULESHOME
 
  The location of the master Modules package file directory containing module
  command initialization scripts, the executable program :file:`modulecmd.tcl`,
  and a directory containing a collection of master *modulefiles*.
 
-.. _MODULES_ADVANCED_VERSION_SPEC:
-
-**MODULES_ADVANCED_VERSION_SPEC**
+.. envvar:: MODULES_ADVANCED_VERSION_SPEC
 
  If set to **1**, enable advanced module version specifiers (see `Advanced
  module version specifiers`_ section). If set to **0**, disable advanced
@@ -942,9 +929,7 @@ ENVIRONMENT
  then the default set in :file:`modulecmd.tcl` script configuration. Which means
  **MODULES_ADVANCED_VERSION_SPEC** overrides default configuration.
 
-.. _MODULES_AUTO_HANDLING:
-
-**MODULES_AUTO_HANDLING**
+.. envvar:: MODULES_AUTO_HANDLING
 
  If set to **1**, enable automated module handling mode. If set to **0**
  disable automated module handling mode. Other values are ignored.
@@ -996,9 +981,7 @@ ENVIRONMENT
  overrides default configuration and **--auto**/**--no-auto** command line
  switches override every other ways to enable or disable this mode.
 
-.. _MODULES_AVAIL_INDEPTH:
-
-**MODULES_AVAIL_INDEPTH**
+.. envvar:: MODULES_AVAIL_INDEPTH
 
  If set to **1**, enable in depth search results for **avail** sub-command. If
  set to **0** disable **avail** sub-command in depth mode. Other values are
@@ -1016,24 +999,18 @@ ENVIRONMENT
  overrides default configuration and **--indepth**/**--no-indepth** command
  line switches override every other ways to enable or disable this mode.
 
-.. _MODULES_CMD:
-
-**MODULES_CMD**
+.. envvar:: MODULES_CMD
 
  The location of the active module command script.
 
-.. _MODULES_COLLECTION_PIN_VERSION:
-
-**MODULES_COLLECTION_PIN_VERSION**
+.. envvar:: MODULES_COLLECTION_PIN_VERSION
 
  If set to **1**, register exact version number of modulefiles when saving a
  collection. Otherwise modulefile version number is omitted if it corresponds
  to the explicitly set default version and also to the implicit default when
  the configuration option *implicit_default* is enabled.
 
-.. _MODULES_COLLECTION_TARGET:
-
-**MODULES_COLLECTION_TARGET**
+.. envvar:: MODULES_COLLECTION_TARGET
 
  The collection target that determines what collections are valid thus
  reachable on the current system.
@@ -1054,9 +1031,7 @@ ENVIRONMENT
  results from commands like :command:`lsb_release`, :command:`hostname`, :command:`dnsdomainname`,
  etc.
 
-.. _MODULES_COLOR:
-
-**MODULES_COLOR**
+.. envvar:: MODULES_COLOR
 
  Defines if output should be colored or not. Accepted values are *never*,
  *auto* and *always*.
@@ -1079,9 +1054,7 @@ ENVIRONMENT
  than **0**. Color mode set with these two variables is superseded by mode set
  with **MODULES_COLOR** environment variable.
 
-.. _MODULES_COLORS:
-
-**MODULES_COLORS**
+.. envvar:: MODULES_COLORS
 
  Specifies the colors and other attributes used to highlight various parts of
  the output. Its value is a colon-separated list of output items associated to
@@ -1114,9 +1087,7 @@ ENVIRONMENT
  :file:`modulecmd.tcl` script configuration. Which means **MODULES_COLORS**
  overrides default configuration.
 
-.. _MODULES_EXTENDED_DEFAULT:
-
-**MODULES_EXTENDED_DEFAULT**
+.. envvar:: MODULES_EXTENDED_DEFAULT
 
  If set to **1**, a specified module version is matched against starting
  portion of existing module versions, where portion is a substring separated
@@ -1132,9 +1103,7 @@ ENVIRONMENT
  This environment variable supersedes the value of the configuration option
  *extended_default* set in :file:`modulecmd.tcl` script.
 
-.. _MODULES_ICASE:
-
-**MODULES_ICASE**
+.. envvar:: MODULES_ICASE
 
  When module specification are passed as argument to module sub-commands or
  modulefile Tcl commands, defines the case sensitiveness to apply to match
@@ -1152,9 +1121,7 @@ ENVIRONMENT
  overrides default configuration and **--icase** command line switch overrides
  every other ways to set case sensitiveness behavior.
 
-.. _MODULES_IMPLICIT_DEFAULT:
-
-**MODULES_IMPLICIT_DEFAULT**
+.. envvar:: MODULES_IMPLICIT_DEFAULT
 
  Defines (if set to **1**) or not (if set to **0**) an implicit default
  version for modules without a default version explicitly defined (see
@@ -1182,9 +1149,7 @@ ENVIRONMENT
  is ignored if *implicit_default* has been declared locked in *locked_configs*
  configuration option.
 
-.. _MODULES_LMALTNAME:
-
-**MODULES_LMALTNAME**
+.. envvar:: MODULES_LMALTNAME
 
  A colon separated list of the alternative names set through
  **module-version** and **module-alias** statements corresponding to all
@@ -1200,9 +1165,7 @@ ENVIRONMENT
  *modulefiles* being loaded when **unload**, **is-loaded** or **info-loaded**
  actions are run over these names.
 
-.. _MODULES_LMCONFLICT:
-
-**MODULES_LMCONFLICT**
+.. envvar:: MODULES_LMCONFLICT
 
  A colon separated list of the **conflict** statements defined by all loaded
  *modulefiles*. Each element in this list starts by the name of the loaded
@@ -1215,9 +1178,7 @@ ENVIRONMENT
  in order to keep environment consistent when a conflicting module is asked
  for load afterward.
 
-.. _MODULES_LMNOTUASKED:
-
-**MODULES_LMNOTUASKED**
+.. envvar:: MODULES_LMNOTUASKED
 
  A colon separated list of all loaded *modulefiles* that were not explicitly
  asked for load from the command-line.
@@ -1226,9 +1187,7 @@ ENVIRONMENT
  use to distinguish the *modulefiles* that have been loaded automatically
  from modulefiles that have been asked by users.
 
-.. _MODULES_LMPREREQ:
-
-**MODULES_LMPREREQ**
+.. envvar:: MODULES_LMPREREQ
 
  A colon separated list of the **prereq** statements defined by all loaded
  *modulefiles*. Each element in this list starts by the name of the loaded
@@ -1243,9 +1202,7 @@ ENVIRONMENT
  *modulefiles* in order to keep environment consistent when a pre-required
  module is asked for unload afterward.
 
-.. _MODULES_PAGER:
-
-**MODULES_PAGER**
+.. envvar:: MODULES_PAGER
 
  Text viewer for use to paginate message output if error output stream is
  attached to a terminal. The value of this variable is composed of a pager
@@ -1259,16 +1216,12 @@ ENVIRONMENT
  If **MODULES_PAGER** variable is set to an empty string or to the value
  *cat*, pager will not be launched.
 
-.. _MODULES_RUNENV_<VAR>:
-
-**MODULES_RUNENV_<VAR>**
+.. envvar:: MODULES_RUNENV_<VAR>
 
  Value to set to environment variable *<VAR>* for :file:`modulecmd.tcl` run-time
  execution if *<VAR>* is referred in **MODULES_RUN_QUARANTINE**.
 
-.. _MODULES_RUN_QUARANTINE:
-
-**MODULES_RUN_QUARANTINE**
+.. envvar:: MODULES_RUN_QUARANTINE
 
  A space separated list of environment variable names that should be passed
  indirectly to :file:`modulecmd.tcl` to protect its run-time environment from
@@ -1281,9 +1234,7 @@ ENVIRONMENT
  Original values of these environment variables set in quarantine are passed
  to :file:`modulecmd.tcl` via **<VAR>_modquar** variables.
 
-.. _MODULES_SEARCH_MATCH:
-
-**MODULES_SEARCH_MATCH**
+.. envvar:: MODULES_SEARCH_MATCH
 
  When searching for modules with **avail** sub-command, defines the way query
  string should match against available module names. With **starts_with**
@@ -1298,9 +1249,7 @@ ENVIRONMENT
  overrides default configuration and **--starts-with**/**--contains** command
  line switches override every other ways to set search match style.
 
-.. _MODULES_SET_SHELL_STARTUP:
-
-**MODULES_SET_SHELL_STARTUP**
+.. envvar:: MODULES_SET_SHELL_STARTUP
 
  If set to **1**, defines when :command:`module` command initializes the shell
  startup file to ensure that the :command:`module` command is still defined in
@@ -1308,18 +1257,14 @@ ENVIRONMENT
  **BASH_ENV** environment variable to the Modules bourne shell initialization
  script. If set to **0**, shell startup file is not defined.
 
-.. _MODULES_SILENT_SHELL_DEBUG:
-
-**MODULES_SILENT_SHELL_DEBUG**
+.. envvar:: MODULES_SILENT_SHELL_DEBUG
 
  If set to **1**, disable any *xtrace* or *verbose* debugging property set on
  current shell session for the duration of either the module command or the
  module shell initialization script. Only applies to Bourne Shell (sh) and its
  derivatives.
 
-.. _MODULES_SITECONFIG:
-
-**MODULES_SITECONFIG**
+.. envvar:: MODULES_SITECONFIG
 
  Location of a site-specific configuration script to source into
  :file:`modulecmd.tcl`. See also Modulecmd startup section.
@@ -1327,26 +1272,20 @@ ENVIRONMENT
  This environment variable is ignored if *extra_siteconfig* has been declared
  locked in *locked_configs* configuration option.
 
-.. _MODULES_TERM_BACKGROUND:
-
-**MODULES_TERM_BACKGROUND**
+.. envvar:: MODULES_TERM_BACKGROUND
 
  Inform Modules of the terminal background color to determine if the color set
  for dark background or the color set for light background should be used to
  color output in case no specific color set is defined with the
  **MODULES_COLORS** variable. Accepted values are **dark** and **light**.
 
-.. _MODULES_UNLOAD_MATCH_ORDER:
-
-**MODULES_UNLOAD_MATCH_ORDER**
+.. envvar:: MODULES_UNLOAD_MATCH_ORDER
 
  When a module unload request matches multiple loaded modules, unload firstly
  loaded module or lastly loaded module. Accepted values are **returnfirst**
  and **returnlast**.
 
-.. _MODULES_USE_COMPAT_VERSION:
-
-**MODULES_USE_COMPAT_VERSION**
+.. envvar:: MODULES_USE_COMPAT_VERSION
 
  If set to **1** prior to Modules package initialization, enable
  Modules compatibility version (3.2 release branch) rather main version
@@ -1354,9 +1293,7 @@ ENVIRONMENT
  version should be installed along with main version for this environment
  variable to have any effect.
 
-.. _MODULES_VERBOSITY:
-
-**MODULES_VERBOSITY**
+.. envvar:: MODULES_VERBOSITY
 
  Defines the verbosity level of the module command. Available verbosity levels
  from the least to the most verbose are:
@@ -1380,9 +1317,7 @@ ENVIRONMENT
  overrides default configuration and **--silent**/**--verbose**/**--debug**
  command line switches overrides every other ways to set verbosity level.
 
-.. _MODULES_WA_277:
-
-**MODULES_WA_277**
+.. envvar:: MODULES_WA_277
 
  If set to **1** prior to Modules package initialization, enables workaround
  for Tcsh history issue (see https://github.com/cea-hpc/modules/issues/277).
@@ -1394,22 +1329,16 @@ ENVIRONMENT
  used anymore in shell alias definition otherwise the evaluation of the code
  produced by modulefiles will return a syntax error.
 
-.. _LMFILES:
-
-**_LMFILES_**
+.. envvar:: _LMFILES_
 
  A colon separated list of the full pathname for all loaded *modulefiles*.
 
-.. _<VAR>_modquar:
-
-**<VAR>_modquar**
+.. envvar:: <VAR>_modquar
 
  Value of environment variable *<VAR>* passed to :file:`modulecmd.tcl` in order
  to restore *<VAR>* to this value once started.
 
-.. _<VAR>_modshare:
-
-**<VAR>_modshare**
+.. envvar:: <VAR>_modshare
 
  Reference counter variable for path-like variable *<VAR>*. A colon
  separated list containing pairs of elements. A pair is formed by a path

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -207,13 +207,13 @@ switches are accepted:
  On **avail** sub-command, display only the default version of each module
  name. Default version is the explicitly set default version or also the
  implicit default version if the configuration option *implicit_default* is enabled
- (see Locating Modulefiles section in the :ref:`modulefile(4)` man page for
+ (see :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page for
  further details on implicit default version).
 
 **--latest**, **-L**
 
  On **avail** sub-command, display only the highest numerically sorted
- version of each module name (see Locating Modulefiles section in the
+ version of each module name (see :ref:`Locating Modulefiles` section in the
  :ref:`modulefile(4)` man page).
 
 **--starts-with**, **-S**
@@ -1158,7 +1158,7 @@ ENVIRONMENT
 
  Defines (if set to **1**) or not (if set to **0**) an implicit default
  version for modules without a default version explicitly defined (see
- Locating Modulefiles section in the :ref:`modulefile(4)` man page).
+ :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page).
 
  Without either an explicit or implicit default version defined a module must
  be fully qualified (version should be specified in addition to its name) to

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -206,7 +206,7 @@ switches are accepted:
 
  On **avail** sub-command, display only the default version of each module
  name. Default version is the explicitly set default version or also the
- implicit default version if **config** option *implicit_default* is enabled
+ implicit default version if the configuration option *implicit_default* is enabled
  (see Locating Modulefiles section in the :ref:`modulefile(4)` man page for
  further details on implicit default version).
 
@@ -398,7 +398,7 @@ Module Sub-Commands
  times *directory* has been enabled. When attempting to remove *directory*
  from **MODULEPATH**, reference counter variable **MODULEPATH_modshare**
  is checked and *directory* is removed only if its relative counter is
- equal to 1 or not defined. Elsewhere *directory* is kept and reference
+ equal to 1 or not defined. Otherwise *directory* is kept and reference
  counter is decreased by 1.
 
 .. _refresh:
@@ -500,7 +500,7 @@ Module Sub-Commands
  of this variable will be appended to the *collection* file name.
 
  By default, if loaded modulefile corresponds to the explicitly defined
- default module version, the bare module name is recorded. If **config**
+ default module version, the bare module name is recorded. If the configuration
  option *implicit_default* is enabled, the bare module name is also recorded
  for the implicit default module version. If
  **MODULES_COLLECTION_PIN_VERSION** is set to **1**, module version is always
@@ -533,7 +533,7 @@ Module Sub-Commands
 
  If a module, without a default version explicitly defined, is recorded in a
  *collection* by its bare name: loading this module when restoring the
- collection will fail if **config** option *implicit_default* is disabled.
+ collection will fail if the configuration option *implicit_default* is disabled.
 
 .. _saverm:
 
@@ -681,7 +681,7 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *modulefiles* has been loaded or if
  any *modulefile* is loaded in case no argument is provided. Returns a false
- value elsewhere. See **is-loaded** in the :ref:`modulefile(4)` man page for
+ value otherwise. See **is-loaded** in the :ref:`modulefile(4)` man page for
  further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -694,7 +694,7 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *collections* exists or if any
  *collection* exists in case no argument is provided. Returns a false value
- elsewhere. See **is-saved** in the :ref:`modulefile(4)` man page for further
+ otherwise. See **is-saved** in the :ref:`modulefile(4)` man page for further
  explanation.
 
 .. _is-used:
@@ -703,7 +703,7 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *directories* has been enabled in
  **MODULEPATH** or if any *directory* is enabled in case no argument is
- provided. Returns a false value elsewhere. See **is-used** in the
+ provided. Returns a false value otherwise. See **is-used** in the
  :ref:`modulefile(4)` man page for further explanation.
 
 .. _is-avail:
@@ -711,7 +711,7 @@ Module Sub-Commands
 **is-avail** modulefile...
 
  Returns a true value if any of the listed *modulefiles* exists in enabled
- **MODULEPATH**. Returns a false value elsewhere. See **is-avail** in the
+ **MODULEPATH**. Returns a false value otherwise. See **is-avail** in the
  :ref:`modulefile(4)` man page for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -876,7 +876,7 @@ the current value of the **MODULES_COLLECTION_TARGET** environment variable
 EXIT STATUS
 -----------
 
-The **module** command exits with **0** if its execution succeed. Elsewhere
+The **module** command exits with **0** if its execution succeed. Otherwise
 **1** is returned.
 
 
@@ -1027,9 +1027,9 @@ ENVIRONMENT
 **MODULES_COLLECTION_PIN_VERSION**
 
  If set to **1**, register exact version number of modulefiles when saving a
- collection. Elsewhere modulefile version number is omitted if it corresponds
+ collection. Otherwise modulefile version number is omitted if it corresponds
  to the explicitly set default version and also to the implicit default when
- **config** option *implicit_default* is enabled.
+ the configuration option *implicit_default* is enabled.
 
 .. _MODULES_COLLECTION_TARGET:
 
@@ -1045,8 +1045,8 @@ ENVIRONMENT
 
  When a target is set, only the collections made for that target are
  available to the **restore**, **savelist**, **saveshow** and **saverm**
- sub-commands. Saving collection registers the target footprint by suffixing
- the collection filename with ``.$MODULES_COLLECTION_TARGET``. Collection
+ sub-commands. Saving a collection registers the target footprint by suffixing
+ the collection filename with ``.$MODULES_COLLECTION_TARGET``. The collection
  target is not involved when collection is specified as file path on the
  **saveshow**, **restore** and **save** sub-commands.
 
@@ -1124,9 +1124,9 @@ ENVIRONMENT
  specified modules ``mod/1`` and ``mod/1.2`` will match existing  modulefile
  ``mod/1.2.3``.
 
- In case multiple modulefiles match specified module version and a single
- module has to be selected, explicitly set default version is returned if it
- is part of matching modulefiles. Elsewhere implicit default among matching
+ In case multiple modulefiles match the specified module version and a single
+ module has to be selected, the explicitly set default version is returned if it
+ is part of matching modulefiles. Otherwise the implicit default among matching
  modulefiles is returned if defined (see **MODULES_IMPLICIT_DEFAULT** section)
 
  This environment variable supersedes the value of the configuration option
@@ -1390,8 +1390,8 @@ ENVIRONMENT
  workaround is enabled, an alternative *module* alias is defined which fixes
  the history mechanism issue. However the alternative definition of the
  *module* alias weakens shell evaluation of the code produced by modulefiles.
- Characters with special meaning for Tcsh shell (like *{* and *}*) may not be
- used anymore in shell alias definition elsewhere the evaluation of the code
+ Characters with a special meaning for Tcsh shell (like *{* and *}*) may not be
+ used anymore in shell alias definition otherwise the evaluation of the code
  produced by modulefiles will return a syntax error.
 
 .. _LMFILES:

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -971,6 +971,10 @@ ENVIRONMENT
  Email address to contact in case any issue occurs during the interpretation
  of modulefiles.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. envvar:: MODULEPATH
 
  The path that the :command:`module` command searches when looking for
@@ -1007,6 +1011,10 @@ ENVIRONMENT
  order of preference: :envvar:`MODULES_ADVANCED_VERSION_SPEC` environment variable
  then the default set in :file:`modulecmd.tcl` script configuration. Which means
  :envvar:`MODULES_ADVANCED_VERSION_SPEC` overrides default configuration.
+
+ .. only:: html
+
+    .. versionadded:: 4.4
 
 .. envvar:: MODULES_AUTO_HANDLING
 
@@ -1060,6 +1068,10 @@ ENVIRONMENT
  overrides default configuration and :option:`--auto`/:option:`--no-auto` command line
  switches override every other ways to enable or disable this mode.
 
+ .. only:: html
+
+    .. versionadded:: 4.2
+
 .. envvar:: MODULES_AVAIL_INDEPTH
 
  If set to ``1``, enable in depth search results for :subcmd:`avail` sub-command. If
@@ -1078,9 +1090,17 @@ ENVIRONMENT
  overrides default configuration and :option:`--indepth`/:option:`--no-indepth` command
  line switches override every other ways to enable or disable this mode.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_CMD
 
  The location of the active module command script.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. envvar:: MODULES_COLLECTION_PIN_VERSION
 
@@ -1088,6 +1108,10 @@ ENVIRONMENT
  collection. Otherwise modulefile version number is omitted if it corresponds
  to the explicitly set default version and also to the implicit default when
  the configuration option ``implicit_default`` is enabled.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. envvar:: MODULES_COLLECTION_TARGET
 
@@ -1109,6 +1133,10 @@ ENVIRONMENT
  For example, the :envvar:`MODULES_COLLECTION_TARGET` variable may be set with
  results from commands like :command:`lsb_release`, :command:`hostname`, :command:`dnsdomainname`,
  etc.
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 .. envvar:: MODULES_COLOR
 
@@ -1132,6 +1160,10 @@ ENVIRONMENT
  The ``always`` mode is set if :envvar:`CLICOLOR_FORCE` is set to a value different
  than ``0``. Color mode set with these two variables is superseded by mode set
  with :envvar:`MODULES_COLOR` environment variable.
+
+ .. only:: html
+
+    .. versionadded:: 4.3
 
 .. envvar:: MODULES_COLORS
 
@@ -1166,6 +1198,10 @@ ENVIRONMENT
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_COLORS`
  overrides default configuration.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_EXTENDED_DEFAULT
 
  If set to ``1``, a specified module version is matched against starting
@@ -1181,6 +1217,10 @@ ENVIRONMENT
 
  This environment variable supersedes the value of the configuration option
  ``extended_default`` set in :file:`modulecmd.tcl` script.
+
+ .. only:: html
+
+    .. versionadded:: 4.4
 
 .. envvar:: MODULES_ICASE
 
@@ -1199,6 +1239,10 @@ ENVIRONMENT
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_ICASE`
  overrides default configuration and :option:`--icase` command line switch overrides
  every other ways to set case sensitiveness behavior.
+
+ .. only:: html
+
+    .. versionadded:: 4.4
 
 .. envvar:: MODULES_IMPLICIT_DEFAULT
 
@@ -1228,6 +1272,10 @@ ENVIRONMENT
  is ignored if ``implicit_default`` has been declared locked in ``locked_configs``
  configuration option.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_LMALTNAME
 
  A colon separated list of the alternative names set through
@@ -1244,6 +1292,10 @@ ENVIRONMENT
  *modulefiles* being loaded when :subcmd:`unload`, :subcmd:`is-loaded` or :subcmd:`info-loaded`
  actions are run over these names.
 
+ .. only:: html
+
+    .. versionadded:: 4.2
+
 .. envvar:: MODULES_LMCONFLICT
 
  A colon separated list of the :mfcmd:`conflict` statements defined by all loaded
@@ -1257,6 +1309,10 @@ ENVIRONMENT
  in order to keep environment consistent when a conflicting module is asked
  for load afterward.
 
+ .. only:: html
+
+    .. versionadded:: 4.2
+
 .. envvar:: MODULES_LMNOTUASKED
 
  A colon separated list of all loaded *modulefiles* that were not explicitly
@@ -1265,6 +1321,10 @@ ENVIRONMENT
  This environment variable is intended for :command:`module` command internal
  use to distinguish the *modulefiles* that have been loaded automatically
  from modulefiles that have been asked by users.
+
+ .. only:: html
+
+    .. versionadded:: 4.2
 
 .. envvar:: MODULES_LMPREREQ
 
@@ -1281,6 +1341,10 @@ ENVIRONMENT
  *modulefiles* in order to keep environment consistent when a pre-required
  module is asked for unload afterward.
 
+ .. only:: html
+
+    .. versionadded:: 4.2
+
 .. envvar:: MODULES_PAGER
 
  Text viewer for use to paginate message output if error output stream is
@@ -1295,10 +1359,18 @@ ENVIRONMENT
  If :envvar:`MODULES_PAGER` variable is set to an empty string or to the value
  ``cat``, pager will not be launched.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. envvar:: MODULES_RUNENV_<VAR>
 
  Value to set to environment variable :envvar:`<VAR>` for :file:`modulecmd.tcl` run-time
  execution if :envvar:`<VAR>` is referred in :envvar:`MODULES_RUN_QUARANTINE`.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. envvar:: MODULES_RUN_QUARANTINE
 
@@ -1312,6 +1384,10 @@ ENVIRONMENT
 
  Original values of these environment variables set in quarantine are passed
  to :file:`modulecmd.tcl` via :envvar:`<VAR>_modquar` variables.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. envvar:: MODULES_SEARCH_MATCH
 
@@ -1328,6 +1404,10 @@ ENVIRONMENT
  overrides default configuration and :option:`--starts-with`/:option:`--contains` command
  line switches override every other ways to set search match style.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_SET_SHELL_STARTUP
 
  If set to ``1``, defines when :command:`module` command initializes the shell
@@ -1336,12 +1416,20 @@ ENVIRONMENT
  :envvar:`BASH_ENV` environment variable to the Modules bourne shell initialization
  script. If set to ``0``, shell startup file is not defined.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_SILENT_SHELL_DEBUG
 
  If set to ``1``, disable any ``xtrace`` or ``verbose`` debugging property set on
  current shell session for the duration of either the module command or the
  module shell initialization script. Only applies to Bourne Shell (sh) and its
  derivatives.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. envvar:: MODULES_SITECONFIG
 
@@ -1351,6 +1439,10 @@ ENVIRONMENT
  This environment variable is ignored if ``extra_siteconfig`` has been declared
  locked in ``locked_configs`` configuration option.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_TERM_BACKGROUND
 
  Inform Modules of the terminal background color to determine if the color set
@@ -1358,11 +1450,19 @@ ENVIRONMENT
  color output in case no specific color set is defined with the
  :envvar:`MODULES_COLORS` variable. Accepted values are ``dark`` and ``light``.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_UNLOAD_MATCH_ORDER
 
  When a module unload request matches multiple loaded modules, unload firstly
  loaded module or lastly loaded module. Accepted values are ``returnfirst``
  and ``returnlast``.
+
+ .. only:: html
+
+    .. versionadded:: 4.3
 
 .. envvar:: MODULES_USE_COMPAT_VERSION
 
@@ -1371,6 +1471,10 @@ ENVIRONMENT
  at initialization scripts running time. Modules package compatibility
  version should be installed along with main version for this environment
  variable to have any effect.
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 .. envvar:: MODULES_VERBOSITY
 
@@ -1396,6 +1500,10 @@ ENVIRONMENT
  overrides default configuration and :option:`--silent`/:option:`--verbose`/:option:`--debug`
  command line switches overrides every other ways to set verbosity level.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: MODULES_WA_277
 
  If set to ``1`` prior to Modules package initialization, enables workaround
@@ -1408,6 +1516,10 @@ ENVIRONMENT
  used anymore in shell alias definition otherwise the evaluation of the code
  produced by modulefiles will return a syntax error.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. envvar:: _LMFILES_
 
  A colon separated list of the full pathname for all loaded *modulefiles*.
@@ -1417,6 +1529,10 @@ ENVIRONMENT
  Value of environment variable :envvar:`<VAR>` passed to :file:`modulecmd.tcl` in order
  to restore :envvar:`<VAR>` to this value once started.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. envvar:: <VAR>_modshare
 
  Reference counter variable for path-like variable :envvar:`<VAR>`. A colon
@@ -1424,6 +1540,10 @@ ENVIRONMENT
  element followed its usage counter which represents the number of times
  this path has been enabled in variable :envvar:`<VAR>`. A colon separates the
  two parts of the pair.
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 
 FILES

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -136,54 +136,54 @@ the :command:`module` behavior in case of locating and interpreting *modulefiles
 All switches may be entered either in short or long notation. The following
 switches are accepted:
 
-**--help**, **-h**
+.. option:: --help, -h
 
  Give some helpful usage information, and terminates the command.
 
-**--version**, **-V**
+.. option:: --version, -V
 
  Lists the current version of the :command:`module` command. The command then
  terminates without further processing.
 
-**--debug**, **-D**
+.. option:: --debug, -D
 
  Debug mode. Causes :command:`module` to print debugging messages about its
  progress.
 
-**--verbose**, **-v**
+.. option:: --verbose, -v
 
  Enable verbose messages during :command:`module` command execution.
 
-**--silent**, **-s**
+.. option:: --silent, -s
 
  Turn off error, warning and informational messages. :command:`module` command output
  result is not affected by silent mode.
 
-**--paginate**
+.. option:: --paginate
 
  Pipe all message output into :command:`less` (or if set, to the command referred in :envvar:`MODULES_PAGER` variable) if error
  output stream is a terminal. See also :envvar:`MODULES_PAGER` section.
 
-**--no-pager**
+.. option:: --no-pager
 
  Do not pipe message output into a pager.
 
-**--color**\[=\ *WHEN*\]
+.. option:: --color=<WHEN>
 
  Colorize the output. *WHEN* defaults to *always* or can be *never* or *auto*.
  See also :envvar:`MODULES_COLOR` section.
 
-**--auto**
+.. option:: --auto
 
  On **load**, **unload** and **switch** sub-commands, enable automated module
  handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
-**--no-auto**
+.. option:: --no-auto
 
  On **load**, **unload** and **switch** sub-commands, disable automated module
  handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
-**--force**, **-f**
+.. option:: --force, -f
 
  On **load**, **unload** and **switch** sub-commands, by-pass any unsatisfied
  modulefile constraint corresponding to the declared **prereq** and
@@ -194,15 +194,15 @@ switches are accepted:
 
  On **clear** sub-command, skip the confirmation dialog and proceed.
 
-**--terse**, **-t**
+.. option:: --terse, -t
 
  Display **avail**, **list** and **savelist** output in short format.
 
-**--long**, **-l**
+.. option:: --long, -l
 
  Display **avail**, **list** and **savelist** output in long format.
 
-**--default**, **-d**
+.. option:: --default, -d
 
  On **avail** sub-command, display only the default version of each module
  name. Default version is the explicitly set default version or also the
@@ -210,35 +210,35 @@ switches are accepted:
  (see :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page for
  further details on implicit default version).
 
-**--latest**, **-L**
+.. option:: --latest, -L
 
  On **avail** sub-command, display only the highest numerically sorted
  version of each module name (see :ref:`Locating Modulefiles` section in the
  :ref:`modulefile(4)` man page).
 
-**--starts-with**, **-S**
+.. option:: --starts-with, -S
 
  On **avail** sub-command, return modules whose name starts with search query
  string.
 
-**--contains**, **-C**
+.. option:: --contains, -C
 
  On **avail** sub-command, return modules whose fully qualified name contains
  search query string.
 
-**--indepth**
+.. option:: --indepth
 
  On **avail** sub-command, include in search results the matching modulefiles
  and directories and recursively the modulefiles and directories contained in
  these matching directories.
 
-**--no-indepth**
+.. option:: --no-indepth
 
  On **avail** sub-command, limit search results to the matching modulefiles
  and directories found at the depth level expressed by the search query. Thus
  modulefiles contained in directories part of the result are excluded.
 
-**--icase**, **-i**
+.. option:: --icase, -i
 
  Match module specification arguments in a case insensitive manner.
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -150,38 +150,74 @@ switches are accepted:
  Debug mode. Causes :command:`module` to print debugging messages about its
  progress.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. option:: --verbose, -v
 
  Enable verbose messages during :command:`module` command execution.
+
+ .. only:: html
+
+    .. versionadded:: 4.3
+       :option:`--verbose`/:option:`-v` support was dropped on version `4.0`
+       but reintroduced starting version `4.3`.
 
 .. option:: --silent, -s
 
  Turn off error, warning and informational messages. :command:`module` command output
  result is not affected by silent mode.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+       :option:`--silent`/:option:`-s` support was dropped on version `4.0`
+       but reintroduced starting version `4.3`.
+
 .. option:: --paginate
 
  Pipe all message output into :command:`less` (or if set, to the command referred in :envvar:`MODULES_PAGER` variable) if error
  output stream is a terminal. See also :envvar:`MODULES_PAGER` section.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. option:: --no-pager
 
  Do not pipe message output into a pager.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. option:: --color=<WHEN>
 
  Colorize the output. *WHEN* defaults to ``always`` or can be ``never`` or ``auto``.
  See also :envvar:`MODULES_COLOR` section.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. option:: --auto
 
  On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, enable automated module
  handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
+ .. only:: html
+
+    .. versionadded:: 4.2
+
 .. option:: --no-auto
 
  On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, disable automated module
  handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
+
+ .. only:: html
+
+    .. versionadded:: 4.2
 
 .. option:: --force, -f
 
@@ -193,6 +229,15 @@ switches are accepted:
  *modulefile*.
 
  On :subcmd:`clear` sub-command, skip the confirmation dialog and proceed.
+
+ .. only:: html
+
+    .. versionadded:: 4.3
+       :option:`--force`/:option:`-f` support was dropped on version `4.0`
+       but reintroduced starting version `4.2` with a different meaning:
+       instead of enabling an active dependency resolution mechanism
+       :option:`--force` command line switch now enables to by-pass dependency
+       consistency when loading or unloading a *modulefile*.
 
 .. option:: --terse, -t
 
@@ -210,21 +255,37 @@ switches are accepted:
  (see :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page for
  further details on implicit default version).
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. option:: --latest, -L
 
  On :subcmd:`avail` sub-command, display only the highest numerically sorted
  version of each module name (see :ref:`Locating Modulefiles` section in the
  :ref:`modulefile(4)` man page).
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. option:: --starts-with, -S
 
  On :subcmd:`avail` sub-command, return modules whose name starts with search query
  string.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. option:: --contains, -C
 
  On :subcmd:`avail` sub-command, return modules whose fully qualified name contains
  search query string.
+
+ .. only:: html
+
+    .. versionadded:: 4.3
 
 .. option:: --indepth
 
@@ -232,15 +293,31 @@ switches are accepted:
  and directories and recursively the modulefiles and directories contained in
  these matching directories.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. option:: --no-indepth
 
  On :subcmd:`avail` sub-command, limit search results to the matching modulefiles
  and directories found at the depth level expressed by the search query. Thus
  modulefiles contained in directories part of the result are excluded.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+
 .. option:: --icase, -i
 
  Match module specification arguments in a case insensitive manner.
+
+ .. only:: html
+
+    .. versionadded:: 4.4
+       :option:`--icase`/:option:`-i` support was dropped on version `4.0`
+       but reintroduced starting version `4.4`. When set, it now applies to
+       search query string and module specificiation on all sub-commands and
+       modulefile Tcl commands.
 
 
 .. _Module Sub-Commands:

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -243,6 +243,8 @@ switches are accepted:
  Match module specification arguments in a case insensitive manner.
 
 
+.. _Module Sub-Commands:
+
 Module Sub-Commands
 ^^^^^^^^^^^^^^^^^^^
 
@@ -1175,7 +1177,7 @@ ENVIRONMENT
 .. envvar:: MODULES_SITECONFIG
 
  Location of a site-specific configuration script to source into
- :file:`modulecmd.tcl`. See also Modulecmd startup section.
+ :file:`modulecmd.tcl`. See also `Modulecmd startup`_ section.
 
  This environment variable is ignored if *extra_siteconfig* has been declared
  locked in *locked_configs* configuration option.

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -186,8 +186,8 @@ switches are accepted:
 .. option:: --force, -f
 
  On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, by-pass any unsatisfied
- modulefile constraint corresponding to the declared **prereq** and
- **conflict**. Which means for instance that a *modulefile* will be loaded
+ modulefile constraint corresponding to the declared :mfcmd:`prereq` and
+ :mfcmd:`conflict`. Which means for instance that a *modulefile* will be loaded
  even if it comes in conflict with another loaded *modulefile* or that a
  *modulefile* will be unloaded even if it is required as a prereq by another
  *modulefile*.
@@ -382,8 +382,8 @@ Module Sub-Commands
  Unload then load all loaded *modulefiles*.
 
  No unload then load is performed and an error is returned if the loaded
- *modulefiles* have unsatisfied constraint corresponding to the **prereq**
- and **conflict** they declare.
+ *modulefiles* have unsatisfied constraint corresponding to the :mfcmd:`prereq`
+ and :mfcmd:`conflict` they declare.
 
 .. subcmd:: purge
 
@@ -404,10 +404,10 @@ Module Sub-Commands
 
 .. subcmd:: whatis [modulefile...]
 
- Display the information set up by the **module-whatis** commands inside
+ Display the information set up by the :mfcmd:`module-whatis` commands inside
  the specified *modulefiles*. These specified *modulefiles* may be
  expressed using wildcard characters. If no *modulefile* is specified,
- all **module-whatis** lines will be shown.
+ all :mfcmd:`module-whatis` lines will be shown.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -423,7 +423,7 @@ Module Sub-Commands
 
 .. subcmd:: search string
 
- Seeks through the **module-whatis** informations of all *modulefiles* for the
+ Seeks through the :mfcmd:`module-whatis` informations of all *modulefiles* for the
  specified *string*. All *module-whatis* informations matching the *string* in
  a case insensitive manner will be displayed. *string* may contain wildcard
  characters.
@@ -457,8 +457,8 @@ Module Sub-Commands
  recorded even if it is the default version.
 
  No *collection* is recorded and an error is returned if the loaded
- *modulefiles* have unsatisfied constraint corresponding to the **prereq**
- and **conflict** they declare.
+ *modulefiles* have unsatisfied constraint corresponding to the :mfcmd:`prereq`
+ and :mfcmd:`conflict` they declare.
 
 .. subcmd:: restore [collection]
 
@@ -580,26 +580,26 @@ Module Sub-Commands
 .. subcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Append *value* to environment *variable*. The *variable* is a colon, or
- *delimiter*, separated list. See **append-path** in the :ref:`modulefile(4)`
+ *delimiter*, separated list. See :mfcmd:`append-path` in the :ref:`modulefile(4)`
  man page for further explanation.
 
 .. subcmd:: prepend-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Prepend *value* to environment *variable*. The *variable* is a colon, or
- *delimiter*, separated list. See **prepend-path** in the :ref:`modulefile(4)`
+ *delimiter*, separated list. See :mfcmd:`prepend-path` in the :ref:`modulefile(4)`
  man page for further explanation.
 
 .. subcmd:: remove-path [-d C|--delim C|--delim=C] [--index] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in environment
- *variable*. See **remove-path** in the :ref:`modulefile(4)` man page for
+ *variable*. See :mfcmd:`remove-path` in the :ref:`modulefile(4)` man page for
  further explanation.
 
 .. subcmd:: is-loaded [modulefile...]
 
  Returns a true value if any of the listed *modulefiles* has been loaded or if
  any *modulefile* is loaded in case no argument is provided. Returns a false
- value otherwise. See **is-loaded** in the :ref:`modulefile(4)` man page for
+ value otherwise. See :mfcmd:`is-loaded` in the :ref:`modulefile(4)` man page for
  further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -610,20 +610,20 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *collections* exists or if any
  *collection* exists in case no argument is provided. Returns a false value
- otherwise. See **is-saved** in the :ref:`modulefile(4)` man page for further
+ otherwise. See :mfcmd:`is-saved` in the :ref:`modulefile(4)` man page for further
  explanation.
 
 .. subcmd:: is-used [directory...]
 
  Returns a true value if any of the listed *directories* has been enabled in
  :envvar:`MODULEPATH` or if any *directory* is enabled in case no argument is
- provided. Returns a false value otherwise. See **is-used** in the
+ provided. Returns a false value otherwise. See :mfcmd:`is-used` in the
  :ref:`modulefile(4)` man page for further explanation.
 
 .. subcmd:: is-avail modulefile...
 
  Returns a true value if any of the listed *modulefiles* exists in enabled
- :envvar:`MODULEPATH`. Returns a false value otherwise. See **is-avail** in the
+ :envvar:`MODULEPATH`. Returns a false value otherwise. See :mfcmd:`is-avail` in the
  :ref:`modulefile(4)` man page for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -634,7 +634,7 @@ Module Sub-Commands
 
  Returns the names of currently loaded modules matching passed *modulefile*.
  Returns an empty string if passed *modulefile* does not match any loaded
- modules. See **module-info loaded** in the :ref:`modulefile(4)` man page for
+ modules. See :mfcmd:`module-info loaded<module-info>` in the :ref:`modulefile(4)` man page for
  further explanation.
 
 .. subcmd:: config [--dump-state|name [value]|--reset name]
@@ -846,30 +846,30 @@ ENVIRONMENT
  loading or unloading a *modulefile* to satisfy the constraints it declares.
  When loading a *modulefile*, following actions are triggered:
 
- * Requirement Load: load of the *modulefiles* declared as a **prereq** of
+ * Requirement Load: load of the *modulefiles* declared as a :mfcmd:`prereq` of
    the loading *modulefile*.
 
- * Dependent Reload: reload of the modulefiles declaring a **prereq** onto
-   loaded *modulefile* or declaring a **prereq** onto a *modulefile* part of
+ * Dependent Reload: reload of the modulefiles declaring a :mfcmd:`prereq` onto
+   loaded *modulefile* or declaring a :mfcmd:`prereq` onto a *modulefile* part of
    this reloading batch.
 
  When unloading a *modulefile*, following actions are triggered:
 
  * Dependent Unload: unload of the modulefiles declaring a non-optional
-   **prereq** onto unloaded modulefile or declaring a non-optional **prereq**
-   onto a modulefile part of this unloading batch. A **prereq** modulefile is
-   considered optional if the **prereq** definition order is made of multiple
+   :mfcmd:`prereq` onto unloaded modulefile or declaring a non-optional :mfcmd:`prereq`
+   onto a modulefile part of this unloading batch. A :mfcmd:`prereq` modulefile is
+   considered optional if the :mfcmd:`prereq` definition order is made of multiple
    modulefiles and at least one alternative modulefile is loaded.
 
- * Useless Requirement Unload: unload of the **prereq** modulefiles that have
+ * Useless Requirement Unload: unload of the :mfcmd:`prereq` modulefiles that have
    been automatically loaded for either the unloaded modulefile, an unloaded
    dependent modulefile or a modulefile part of this useless requirement
    unloading batch. Modulefiles are added to this unloading batch only if
    they are not required by any other loaded modulefiles.
 
- * Dependent Reload: reload of the modulefiles declaring a **conflict** or an
-   optional **prereq** onto either the unloaded modulefile, an unloaded
-   dependent or an unloaded useless requirement or declaring a **prereq** onto
+ * Dependent Reload: reload of the modulefiles declaring a :mfcmd:`conflict` or an
+   optional :mfcmd:`prereq` onto either the unloaded modulefile, an unloaded
+   dependent or an unloaded useless requirement or declaring a :mfcmd:`prereq` onto
    a modulefile part of this reloading batch.
 
  In case a loaded *modulefile* has some of its declared constraints
@@ -1047,7 +1047,7 @@ ENVIRONMENT
 
  * automatically loaded by automated module handling mechanisms (see
    :envvar:`MODULES_AUTO_HANDLING` section) when declared as module requirement,
-   with **prereq** or **module load** modulefile commands.
+   with :mfcmd:`prereq` or :mfcmd:`module load<module>` modulefile commands.
 
  An error is returned in the above situations if either no explicit or
  implicit default version is defined.
@@ -1060,7 +1060,7 @@ ENVIRONMENT
 .. envvar:: MODULES_LMALTNAME
 
  A colon separated list of the alternative names set through
- **module-version** and **module-alias** statements corresponding to all
+ :mfcmd:`module-version` and :mfcmd:`module-alias` statements corresponding to all
  loaded *modulefiles*. Each element in this list starts by the name of the
  loaded *modulefile* followed by all alternative names resolving to it. The
  loaded modulefile and its alternative names are separated by the ampersand
@@ -1075,7 +1075,7 @@ ENVIRONMENT
 
 .. envvar:: MODULES_LMCONFLICT
 
- A colon separated list of the **conflict** statements defined by all loaded
+ A colon separated list of the :mfcmd:`conflict` statements defined by all loaded
  *modulefiles*. Each element in this list starts by the name of the loaded
  *modulefile* declaring the conflict followed by the name of all modulefiles
  it declares a conflict with. These loaded modulefiles and conflicting
@@ -1097,12 +1097,12 @@ ENVIRONMENT
 
 .. envvar:: MODULES_LMPREREQ
 
- A colon separated list of the **prereq** statements defined by all loaded
+ A colon separated list of the :mfcmd:`prereq` statements defined by all loaded
  *modulefiles*. Each element in this list starts by the name of the loaded
  *modulefile* declaring the pre-requirement followed by the name of all
  modulefiles it declares a prereq with. These loaded modulefiles and
  pre-required modulefile names are separated by the ampersand character. When
- a **prereq** statement is composed of multiple modulefiles, these modulefile
+ a :mfcmd:`prereq` statement is composed of multiple modulefiles, these modulefile
  names are separated by the pipe character.
 
  This environment variable is intended for :command:`module` command internal

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -55,7 +55,7 @@ python, perl, ruby, tcl, cmake, r and lisp "shells" are supported which
 writes the environment changes to stdout as python, perl, ruby, tcl, lisp,
 r or cmake code.
 
-Initialization may also be performed by calling the **autoinit** sub-command
+Initialization may also be performed by calling the :subcmd:`autoinit` sub-command
 of the :file:`modulecmd.tcl` program. Evaluation into the shell of the result
 of this command defines the :command:`module` alias or function.
 
@@ -92,7 +92,7 @@ Python:
      exec(open('\ |initdir|\ /python.py').read())
      module('load', 'modulefile', 'modulefile', '...')
 
-Bourne Shell (sh) (and derivatives) with **autoinit** sub-command:
+Bourne Shell (sh) (and derivatives) with :subcmd:`autoinit` sub-command:
 
 .. parsed-literal::
 
@@ -175,36 +175,36 @@ switches are accepted:
 
 .. option:: --auto
 
- On **load**, **unload** and **switch** sub-commands, enable automated module
+ On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, enable automated module
  handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
 .. option:: --no-auto
 
- On **load**, **unload** and **switch** sub-commands, disable automated module
+ On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, disable automated module
  handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
 .. option:: --force, -f
 
- On **load**, **unload** and **switch** sub-commands, by-pass any unsatisfied
+ On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, by-pass any unsatisfied
  modulefile constraint corresponding to the declared **prereq** and
  **conflict**. Which means for instance that a *modulefile* will be loaded
  even if it comes in conflict with another loaded *modulefile* or that a
  *modulefile* will be unloaded even if it is required as a prereq by another
  *modulefile*.
 
- On **clear** sub-command, skip the confirmation dialog and proceed.
+ On :subcmd:`clear` sub-command, skip the confirmation dialog and proceed.
 
 .. option:: --terse, -t
 
- Display **avail**, **list** and **savelist** output in short format.
+ Display :subcmd:`avail`, :subcmd:`list` and :subcmd:`savelist` output in short format.
 
 .. option:: --long, -l
 
- Display **avail**, **list** and **savelist** output in long format.
+ Display :subcmd:`avail`, :subcmd:`list` and :subcmd:`savelist` output in long format.
 
 .. option:: --default, -d
 
- On **avail** sub-command, display only the default version of each module
+ On :subcmd:`avail` sub-command, display only the default version of each module
  name. Default version is the explicitly set default version or also the
  implicit default version if the configuration option *implicit_default* is enabled
  (see :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page for
@@ -212,29 +212,29 @@ switches are accepted:
 
 .. option:: --latest, -L
 
- On **avail** sub-command, display only the highest numerically sorted
+ On :subcmd:`avail` sub-command, display only the highest numerically sorted
  version of each module name (see :ref:`Locating Modulefiles` section in the
  :ref:`modulefile(4)` man page).
 
 .. option:: --starts-with, -S
 
- On **avail** sub-command, return modules whose name starts with search query
+ On :subcmd:`avail` sub-command, return modules whose name starts with search query
  string.
 
 .. option:: --contains, -C
 
- On **avail** sub-command, return modules whose fully qualified name contains
+ On :subcmd:`avail` sub-command, return modules whose fully qualified name contains
  search query string.
 
 .. option:: --indepth
 
- On **avail** sub-command, include in search results the matching modulefiles
+ On :subcmd:`avail` sub-command, include in search results the matching modulefiles
  and directories and recursively the modulefiles and directories contained in
  these matching directories.
 
 .. option:: --no-indepth
 
- On **avail** sub-command, limit search results to the matching modulefiles
+ On :subcmd:`avail` sub-command, limit search results to the matching modulefiles
  and directories found at the depth level expressed by the search query. Thus
  modulefiles contained in directories part of the result are excluded.
 
@@ -257,7 +257,7 @@ Module Sub-Commands
 
 .. subcmd:: add modulefile...
 
- See **load**.
+ See :subcmd:`load`.
 
 .. subcmd:: load [--auto|--no-auto] [-f] modulefile...
 
@@ -269,7 +269,7 @@ Module Sub-Commands
 
 .. subcmd:: rm modulefile...
 
- See **unload**.
+ See :subcmd:`unload`.
 
 .. subcmd:: unload [--auto|--no-auto] [-f] modulefile...
 
@@ -281,7 +281,7 @@ Module Sub-Commands
 
 .. subcmd:: swap [modulefile1] modulefile2
 
- See **switch**.
+ See :subcmd:`switch`.
 
 .. subcmd:: switch [--auto|--no-auto] [-f] [modulefile1] modulefile2
 
@@ -295,7 +295,7 @@ Module Sub-Commands
 
 .. subcmd:: show modulefile...
 
- See **display**.
+ See :subcmd:`display`.
 
 .. subcmd:: display modulefile...
 
@@ -347,7 +347,7 @@ Module Sub-Commands
 
  List all available symbolic version-names and aliases in the current
  :envvar:`MODULEPATH`.  All directories in the :envvar:`MODULEPATH` are recursively
- searched in the same manner than for the **avail** sub-command. Only the
+ searched in the same manner than for the :subcmd:`avail` sub-command. Only the
  symbolic version-names and aliases found in the search are displayed.
 
 .. subcmd:: use [-a|--append] directory...
@@ -375,7 +375,7 @@ Module Sub-Commands
 
 .. subcmd:: refresh
 
- See **reload**.
+ See :subcmd:`reload`.
 
 .. subcmd:: reload
 
@@ -400,7 +400,7 @@ Module Sub-Commands
  Execute *scriptfile* into the shell environment. *scriptfile* must be written
  with *modulefile* syntax and specified with a fully qualified path. Once
  executed *scriptfile* is not marked loaded in shell environment which differ
- from **load** sub-command.
+ from :subcmd:`load` sub-command.
 
 .. subcmd:: whatis [modulefile...]
 
@@ -415,11 +415,11 @@ Module Sub-Commands
 
 .. subcmd:: apropos string
 
- See **search**.
+ See :subcmd:`search`.
 
 .. subcmd:: keyword string
 
- See **search**.
+ See :subcmd:`search`.
 
 .. subcmd:: search string
 
@@ -534,15 +534,15 @@ Module Sub-Commands
 
   :file:`.modules`, :file:`.config/fish/config.fish`
 
- If a **module load** line is found in any of these files, the *modulefiles*
- are appended to any existing list of *modulefiles*. The **module load**
+ If a ``module load`` line is found in any of these files, the *modulefiles*
+ are appended to any existing list of *modulefiles*. The ``module load``
  line must be located in at least one of the files listed above for any of
- the **init** sub-commands to work properly. If the **module load** line is
+ the :subcmd:`init<initadd>` sub-commands to work properly. If the ``module load`` line is
  found in multiple shell initialization files, all of the lines are changed.
 
 .. subcmd:: initprepend modulefile...
 
- Does the same as **initadd** but prepends the given modules to the
+ Does the same as :subcmd:`initadd` but prepends the given modules to the
  beginning of the list.
 
 .. subcmd:: initrm modulefile...
@@ -664,12 +664,12 @@ Module Sub-Commands
    :envvar:`MODULES_ADVANCED_VERSION_SPEC` when set
  * auto_handling: automated module handling mode (defines
    :envvar:`MODULES_AUTO_HANDLING`)
- * avail_indepth: **avail** sub-command in depth search mode (defines
+ * avail_indepth: :subcmd:`avail` sub-command in depth search mode (defines
    :envvar:`MODULES_AVAIL_INDEPTH`)
  * avail_report_dir_sym: display symbolic versions targeting directories on
-   **avail** sub-command
+   :subcmd:`avail` sub-command
  * avail_report_mfile_sym: display symbolic versions targeting modulefiles on
-   **avail** sub-command
+   :subcmd:`avail` sub-command
  * collection_pin_version: register exact modulefile version in collection
    (defines :envvar:`MODULES_COLLECTION_PIN_VERSION`)
  * collection_target: collection target which is valid for current system
@@ -722,7 +722,7 @@ statements. Thus the effect a *modulefile* will have on the environment
 may change depending upon the current state of the environment.
 
 Environment variables are unset when unloading a *modulefile*. Thus, it is
-possible to **load** a *modulefile* and then **unload** it without having
+possible to :subcmd:`load` a *modulefile* and then :subcmd:`unload` it without having
 the environment variables return to their prior state.
 
 
@@ -764,14 +764,14 @@ comparison.
 Collections
 ^^^^^^^^^^^
 
-Collections describe a sequence of **module use** then **module load**
+Collections describe a sequence of :subcmd:`module use<use>` then :subcmd:`module load<load>`
 commands that are interpreted by :file:`modulecmd.tcl` to set the user
 environment as described by this sequence. When a collection is activated,
-with the **restore** sub-command, module paths and loaded modules are
+with the :subcmd:`restore` sub-command, module paths and loaded modules are
 unused or unloaded if they are not part or if they are not ordered the
 same way as in the collection.
 
-Collections are generated by the **save** sub-command that dumps the current
+Collections are generated by the :subcmd:`save` sub-command that dumps the current
 user environment state in terms of module paths and loaded modules. By
 default collections are saved under the :file:`$HOME/.module` directory.
 
@@ -805,7 +805,7 @@ ENVIRONMENT
  The path that the :command:`module` command searches when looking for
  *modulefiles*. Typically, it is set to the master *modulefiles* directory,
  |file modulefilesdir|, by the initialization script. :envvar:`MODULEPATH`
- can be set using **module use** or by the module initialization script
+ can be set using :subcmd:`module use<use>` or by the module initialization script
  to search group or personal *modulefile* directories before or after the
  master *modulefile* directory.
 
@@ -877,7 +877,7 @@ ENVIRONMENT
  loaded for instance), this loaded *modulefile* is excluded from the automatic
  reload actions described above.
 
- For the specific case of the **switch** sub-command, where a modulefile is
+ For the specific case of the :subcmd:`switch` sub-command, where a modulefile is
  unloaded to then load another modulefile. Dependent modulefiles to Unload are
  merged into the Dependent modulefiles to Reload that are reloaded after the
  load of the switched-to modulefile.
@@ -891,8 +891,8 @@ ENVIRONMENT
 
 .. envvar:: MODULES_AVAIL_INDEPTH
 
- If set to **1**, enable in depth search results for **avail** sub-command. If
- set to **0** disable **avail** sub-command in depth mode. Other values are
+ If set to **1**, enable in depth search results for :subcmd:`avail` sub-command. If
+ set to **0** disable :subcmd:`avail` sub-command in depth mode. Other values are
  ignored.
 
  When in depth mode is enabled, modulefiles and directories contained in
@@ -900,7 +900,7 @@ ENVIRONMENT
  disabled these modulefiles and directories contained in matching directories
  are excluded.
 
- **avail** sub-command in depth mode enablement is defined in the following
+ :subcmd:`avail` sub-command in depth mode enablement is defined in the following
  order of preference: :option:`--indepth`/:option:`--no-indepth` command line switches,
  then :envvar:`MODULES_AVAIL_INDEPTH` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AVAIL_INDEPTH`
@@ -929,11 +929,11 @@ ENVIRONMENT
  it happens a collection made on machine 1 may be erroneous on machine 2.
 
  When a target is set, only the collections made for that target are
- available to the **restore**, **savelist**, **saveshow** and **saverm**
+ available to the :subcmd:`restore`, :subcmd:`savelist`, :subcmd:`saveshow` and :subcmd:`saverm`
  sub-commands. Saving a collection registers the target footprint by suffixing
  the collection filename with ``.$MODULES_COLLECTION_TARGET``. The collection
  target is not involved when collection is specified as file path on the
- **saveshow**, **restore** and **save** sub-commands.
+ :subcmd:`saveshow`, :subcmd:`restore` and :subcmd:`save` sub-commands.
 
  For example, the :envvar:`MODULES_COLLECTION_TARGET` variable may be set with
  results from commands like :command:`lsb_release`, :command:`hostname`, :command:`dnsdomainname`,
@@ -1017,7 +1017,7 @@ ENVIRONMENT
  modulefile Tcl commands, defines the case sensitiveness to apply to match
  them. When :envvar:`MODULES_ICASE` is set to **never**, a case sensitive match is
  applied in any cases. When set to **search**, a case insensitive match is
- applied to the **avail**, **whatis** and **paths** sub-commands. When set to
+ applied to the :subcmd:`avail`, :subcmd:`whatis` and :subcmd:`paths` sub-commands. When set to
  **always**, a case insensitive match is also applied to the other module
  sub-commands and modulefile Tcl commands for the module specification they
  receive as argument.
@@ -1039,8 +1039,8 @@ ENVIRONMENT
  be fully qualified (version should be specified in addition to its name) to
  get:
 
- * targeted by module **load**, **switch**, **display**, **help**, **test**
-   and **path** sub-commands.
+ * targeted by module :subcmd:`load`, :subcmd:`switch`, :subcmd:`display`, :subcmd:`help`, :subcmd:`test`
+   and :subcmd:`path` sub-commands.
 
  * restored from a collection, unless already loaded in collection-specified
    order.
@@ -1070,7 +1070,7 @@ ENVIRONMENT
  get knowledge of the alternative names matching loaded *modulefiles* in order
  to keep environment consistent when conflicts or pre-requirements are set
  over these alternative designations. It also helps to find a match after
- *modulefiles* being loaded when **unload**, **is-loaded** or **info-loaded**
+ *modulefiles* being loaded when :subcmd:`unload`, :subcmd:`is-loaded` or :subcmd:`info-loaded`
  actions are run over these names.
 
 .. envvar:: MODULES_LMCONFLICT
@@ -1144,7 +1144,7 @@ ENVIRONMENT
 
 .. envvar:: MODULES_SEARCH_MATCH
 
- When searching for modules with **avail** sub-command, defines the way query
+ When searching for modules with :subcmd:`avail` sub-command, defines the way query
  string should match against available module names. With **starts_with**
  value, returned modules are those whose name begins by search query string.
  When set to **contains**, any modules whose fully qualified name contains
@@ -1213,7 +1213,7 @@ ENVIRONMENT
  * normal: turn on informational messages, like a report of the additional
    module evaluations triggered by loading or unloading modules, aborted
    evaluation issues or a report of each module evaluation occurring during a
-   **restore** or **source** sub-commands.
+   :subcmd:`restore` or :subcmd:`source` sub-commands.
  * verbose: add additional informational messages, like a systematic report of
    the loading or unloading module evaluations.
  * debug: print debugging messages about module command execution.

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -13,37 +13,37 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-**module** is a user interface to the Modules package. The Modules
+:command:`module` is a user interface to the Modules package. The Modules
 package provides for the dynamic modification of the user's environment
 via *modulefiles*.
 
 Each *modulefile* contains the information needed to configure the
 shell for an application. Once the Modules package is initialized, the
-environment can be modified on a per-module basis using the **module**
+environment can be modified on a per-module basis using the :command:`module`
 command which interprets *modulefiles*. Typically *modulefiles* instruct
-the **module** command to alter or set shell environment variables such
+the :command:`module` command to alter or set shell environment variables such
 as **PATH**, **MANPATH**, etc. *Modulefiles* may be shared by many users
 on a system and users may have their own set to supplement or replace the
 shared *modulefiles*.
 
 The *modulefiles* are added to and removed from the current environment
 by the user. The environment changes contained in a *modulefile* can be
-summarized through the **module** command as well. If no arguments are
-given, a summary of the **module** usage and *sub-commands* are shown.
+summarized through the :command:`module` command as well. If no arguments are
+given, a summary of the :command:`module` usage and *sub-commands* are shown.
 
-The action for the **module** command to take is described by the
+The action for the :command:`module` command to take is described by the
 *sub-command* and its associated arguments.
 
 
 Package Initialization
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The Modules package and the **module** command are initialized when a
+The Modules package and the :command:`module` command are initialized when a
 shell-specific initialization script is sourced into the shell. The script
-creates the **module** command as either an alias or function and creates
+creates the :command:`module` command as either an alias or function and creates
 Modules environment variables.
 
-The **module** alias or function executes the :file:`modulecmd.tcl` program
+The :command:`module` alias or function executes the :file:`modulecmd.tcl` program
 located in |emph libexecdir| and has the shell evaluate the command's
 output. The first argument to :file:`modulecmd.tcl` specifies the type of shell.
 
@@ -57,7 +57,7 @@ r or cmake code.
 
 Initialization may also be performed by calling the **autoinit** sub-command
 of the :file:`modulecmd.tcl` program. Evaluation into the shell of the result
-of this command defines the **module** alias or function.
+of this command defines the :command:`module` alias or function.
 
 
 Examples of initialization
@@ -129,9 +129,9 @@ in the following order:
 Command line switches
 ^^^^^^^^^^^^^^^^^^^^^
 
-The **module** command accepts command line switches as its first parameter.
+The :command:`module` command accepts command line switches as its first parameter.
 These may be used to control output format of all information displayed and
-the **module** behavior in case of locating and interpreting *modulefiles*.
+the :command:`module` behavior in case of locating and interpreting *modulefiles*.
 
 All switches may be entered either in short or long notation. The following
 switches are accepted:
@@ -142,26 +142,26 @@ switches are accepted:
 
 **--version**, **-V**
 
- Lists the current version of the **module** command. The command then
+ Lists the current version of the :command:`module` command. The command then
  terminates without further processing.
 
 **--debug**, **-D**
 
- Debug mode. Causes **module** to print debugging messages about its
+ Debug mode. Causes :command:`module` to print debugging messages about its
  progress.
 
 **--verbose**, **-v**
 
- Enable verbose messages during **module** command execution.
+ Enable verbose messages during :command:`module` command execution.
 
 **--silent**, **-s**
 
- Turn off error, warning and informational messages. **module** command output
+ Turn off error, warning and informational messages. :command:`module` command output
  result is not affected by silent mode.
 
 **--paginate**
 
- Pipe all message output into *less* (or if set, *$MODULES_PAGER*) if error
+ Pipe all message output into :command:`less` (or if set, *$MODULES_PAGER*) if error
  output stream is a terminal. See also **MODULES_PAGER** section.
 
 **--no-pager**
@@ -876,7 +876,7 @@ the current value of the **MODULES_COLLECTION_TARGET** environment variable
 EXIT STATUS
 -----------
 
-The **module** command exits with **0** if its execution succeed. Otherwise
+The :command:`module` command exits with **0** if its execution succeed. Otherwise
 **1** is returned.
 
 
@@ -901,7 +901,7 @@ ENVIRONMENT
 
 **MODULEPATH**
 
- The path that the **module** command searches when looking for
+ The path that the :command:`module` command searches when looking for
  *modulefiles*. Typically, it is set to the master *modulefiles* directory,
  |emph prefix|\ */modulefiles*, by the initialization script. **MODULEPATH**
  can be set using **module use** or by the module initialization script
@@ -910,7 +910,7 @@ ENVIRONMENT
 
  Path elements registered in the **MODULEPATH** environment variable may
  contain reference to environment variables which are converted to their
- corresponding value by **module** command each time it looks at the
+ corresponding value by :command:`module` command each time it looks at the
  **MODULEPATH** value. If an environment variable referred in a path element
  is not defined, its reference is converted to an empty string.
 
@@ -1051,7 +1051,7 @@ ENVIRONMENT
  **saveshow**, **restore** and **save** sub-commands.
 
  For example, the **MODULES_COLLECTION_TARGET** variable may be set with
- results from commands like **lsb_release**, **hostname**, **dnsdomainname**,
+ results from commands like :command:`lsb_release`, :command:`hostname`, :command:`dnsdomainname`,
  etc.
 
 .. _MODULES_COLOR:
@@ -1193,7 +1193,7 @@ ENVIRONMENT
  loaded modulefile and its alternative names are separated by the ampersand
  character.
 
- This environment variable is intended for **module** command internal use to
+ This environment variable is intended for :command:`module` command internal use to
  get knowledge of the alternative names matching loaded *modulefiles* in order
  to keep environment consistent when conflicts or pre-requirements are set
  over these alternative designations. It also helps to find a match after
@@ -1210,7 +1210,7 @@ ENVIRONMENT
  it declares a conflict with. These loaded modulefiles and conflicting
  modulefile names are separated by the ampersand character.
 
- This environment variable is intended for **module** command internal
+ This environment variable is intended for :command:`module` command internal
  use to get knowledge of the conflicts declared by the loaded *modulefiles*
  in order to keep environment consistent when a conflicting module is asked
  for load afterward.
@@ -1222,7 +1222,7 @@ ENVIRONMENT
  A colon separated list of all loaded *modulefiles* that were not explicitly
  asked for load from the command-line.
 
- This environment variable is intended for **module** command internal
+ This environment variable is intended for :command:`module` command internal
  use to distinguish the *modulefiles* that have been loaded automatically
  from modulefiles that have been asked by users.
 
@@ -1238,7 +1238,7 @@ ENVIRONMENT
  a **prereq** statement is composed of multiple modulefiles, these modulefile
  names are separated by the pipe character.
 
- This environment variable is intended for **module** command internal
+ This environment variable is intended for :command:`module` command internal
  use to get knowledge of the pre-requirement declared by the loaded
  *modulefiles* in order to keep environment consistent when a pre-required
  module is asked for unload afterward.
@@ -1302,8 +1302,8 @@ ENVIRONMENT
 
 **MODULES_SET_SHELL_STARTUP**
 
- If set to **1**, defines when **module** command initializes the shell
- startup file to ensure that the **module** command is still defined in
+ If set to **1**, defines when :command:`module` command initializes the shell
+ startup file to ensure that the :command:`module` command is still defined in
  sub-shells. Setting shell startup file means defining the **ENV** and
  **BASH_ENV** environment variable to the Modules bourne shell initialization
  script. If set to **0**, shell startup file is not defined.
@@ -1453,7 +1453,7 @@ FILES
 |bold libexecdir|\ **/modulecmd.tcl**
 
  The *modulefile* interpreter that gets executed upon each invocation
- of **module**.
+ of :command:`module`.
 
 |bold initdir|\ **/<shell>**
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -22,9 +22,9 @@ shell for an application. Once the Modules package is initialized, the
 environment can be modified on a per-module basis using the :command:`module`
 command which interprets *modulefiles*. Typically *modulefiles* instruct
 the :command:`module` command to alter or set shell environment variables such
-as :envvar:`PATH`, :envvar:`MANPATH`, etc. *Modulefiles* may be shared by many users
-on a system and users may have their own set to supplement or replace the
-shared *modulefiles*.
+as :envvar:`PATH`, :envvar:`MANPATH`, etc. *Modulefiles* may be shared by many
+users on a system and users may have their own set to supplement or replace
+the shared *modulefiles*.
 
 The *modulefiles* are added to and removed from the current environment
 by the user. The environment changes contained in a *modulefile* can be
@@ -40,12 +40,13 @@ Package Initialization
 
 The Modules package and the :command:`module` command are initialized when a
 shell-specific initialization script is sourced into the shell. The script
-creates the :command:`module` command as either an alias or function and creates
-Modules environment variables.
+creates the :command:`module` command as either an alias or function and
+creates Modules environment variables.
 
-The :command:`module` alias or function executes the :file:`modulecmd.tcl` program
-located in |file libexecdir| and has the shell evaluate the command's
-output. The first argument to :file:`modulecmd.tcl` specifies the type of shell.
+The :command:`module` alias or function executes the :file:`modulecmd.tcl`
+program located in |file libexecdir| and has the shell evaluate the command's
+output. The first argument to :file:`modulecmd.tcl` specifies the type of
+shell.
 
 The initialization scripts are kept in |file initdir_shell| where
 *<shell>* is the name of the sourcing shell. For example, a C Shell user
@@ -55,9 +56,9 @@ python, perl, ruby, tcl, cmake, r and lisp "shells" are supported which
 writes the environment changes to stdout as python, perl, ruby, tcl, lisp,
 r or cmake code.
 
-Initialization may also be performed by calling the :subcmd:`autoinit` sub-command
-of the :file:`modulecmd.tcl` program. Evaluation into the shell of the result
-of this command defines the :command:`module` alias or function.
+Initialization may also be performed by calling the :subcmd:`autoinit`
+sub-command of the :file:`modulecmd.tcl` program. Evaluation into the shell of
+the result of this command defines the :command:`module` alias or function.
 
 
 Examples of initialization
@@ -105,10 +106,11 @@ Modulecmd startup
 Upon invocation :file:`modulecmd.tcl` sources a site-specific configuration
 script if it exists. The location for this script is
 |file etcdir_siteconfig|. An additional siteconfig script may be
-specified with the :envvar:`MODULES_SITECONFIG` environment variable, if allowed by
-:file:`modulecmd.tcl` configuration, and will be loaded if it exists after
-|file etcdir_siteconfig|. Siteconfig is a Tcl script that enables to
-supersede any global variable or procedure definition of :file:`modulecmd.tcl`.
+specified with the :envvar:`MODULES_SITECONFIG` environment variable, if
+allowed by :file:`modulecmd.tcl` configuration, and will be loaded if it
+exists after |file etcdir_siteconfig|. Siteconfig is a Tcl script that enables
+to supersede any global variable or procedure definition of
+:file:`modulecmd.tcl`.
 
 Afterward, :file:`modulecmd.tcl` sources rc files which contain global,
 user and *modulefile* specific setups. These files are interpreted as
@@ -117,21 +119,23 @@ user and *modulefile* specific setups. These files are interpreted as
 Upon invocation of :file:`modulecmd.tcl` module run-command files are sourced
 in the following order:
 
-1. Global RC file as specified by :envvar:`MODULERCFILE` variable or |file etcdir_rc|.
-   If :envvar:`MODULERCFILE` points to a directory, the :file:`modulerc` file in this
-   directory is used as global RC file.
+1. Global RC file as specified by :envvar:`MODULERCFILE` variable or
+   |file etcdir_rc|. If :envvar:`MODULERCFILE` points to a directory, the
+   :file:`modulerc` file in this directory is used as global RC file.
 
 2. User specific module RC file :file:`$HOME/.modulerc`
 
-3. All :file:`.modulerc` and :file:`.version` files found during modulefile seeking.
+3. All :file:`.modulerc` and :file:`.version` files found during modulefile
+   seeking.
 
 
 Command line switches
 ^^^^^^^^^^^^^^^^^^^^^
 
-The :command:`module` command accepts command line switches as its first parameter.
-These may be used to control output format of all information displayed and
-the :command:`module` behavior in case of locating and interpreting *modulefiles*.
+The :command:`module` command accepts command line switches as its first
+parameter. These may be used to control output format of all information
+displayed and the :command:`module` behavior in case of locating and
+interpreting *modulefiles*.
 
 All switches may be entered either in short or long notation. The following
 switches are accepted:
@@ -166,8 +170,8 @@ switches are accepted:
 
 .. option:: --silent, -s
 
- Turn off error, warning and informational messages. :command:`module` command output
- result is not affected by silent mode.
+ Turn off error, warning and informational messages. :command:`module` command
+ output result is not affected by silent mode.
 
  .. only:: html
 
@@ -177,8 +181,9 @@ switches are accepted:
 
 .. option:: --paginate
 
- Pipe all message output into :command:`less` (or if set, to the command referred in :envvar:`MODULES_PAGER` variable) if error
- output stream is a terminal. See also :envvar:`MODULES_PAGER` section.
+ Pipe all message output into :command:`less` (or if set, to the command
+ referred in :envvar:`MODULES_PAGER` variable) if error output stream is a
+ terminal. See also :envvar:`MODULES_PAGER` section.
 
  .. only:: html
 
@@ -194,8 +199,8 @@ switches are accepted:
 
 .. option:: --color=<WHEN>
 
- Colorize the output. *WHEN* defaults to ``always`` or can be ``never`` or ``auto``.
- See also :envvar:`MODULES_COLOR` section.
+ Colorize the output. *WHEN* defaults to ``always`` or can be ``never`` or
+ ``auto``. See also :envvar:`MODULES_COLOR` section.
 
  .. only:: html
 
@@ -203,8 +208,9 @@ switches are accepted:
 
 .. option:: --auto
 
- On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, enable automated module
- handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
+ On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, enable
+ automated module handling mode. See also :envvar:`MODULES_AUTO_HANDLING`
+ section.
 
  .. only:: html
 
@@ -212,8 +218,9 @@ switches are accepted:
 
 .. option:: --no-auto
 
- On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, disable automated module
- handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
+ On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands,
+ disable automated module handling mode. See also
+ :envvar:`MODULES_AUTO_HANDLING` section.
 
  .. only:: html
 
@@ -221,12 +228,12 @@ switches are accepted:
 
 .. option:: --force, -f
 
- On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands, by-pass any unsatisfied
- modulefile constraint corresponding to the declared :mfcmd:`prereq` and
- :mfcmd:`conflict`. Which means for instance that a *modulefile* will be loaded
- even if it comes in conflict with another loaded *modulefile* or that a
- *modulefile* will be unloaded even if it is required as a prereq by another
- *modulefile*.
+ On :subcmd:`load`, :subcmd:`unload` and :subcmd:`switch` sub-commands,
+ by-pass any unsatisfied modulefile constraint corresponding to the declared
+ :mfcmd:`prereq` and :mfcmd:`conflict`. Which means for instance that a
+ *modulefile* will be loaded even if it comes in conflict with another loaded
+ *modulefile* or that a *modulefile* will be unloaded even if it is required
+ as a prereq by another *modulefile*.
 
  On :subcmd:`clear` sub-command, skip the confirmation dialog and proceed.
 
@@ -241,19 +248,22 @@ switches are accepted:
 
 .. option:: --terse, -t
 
- Display :subcmd:`avail`, :subcmd:`list` and :subcmd:`savelist` output in short format.
+ Display :subcmd:`avail`, :subcmd:`list` and :subcmd:`savelist` output in
+ short format.
 
 .. option:: --long, -l
 
- Display :subcmd:`avail`, :subcmd:`list` and :subcmd:`savelist` output in long format.
+ Display :subcmd:`avail`, :subcmd:`list` and :subcmd:`savelist` output in long
+ format.
 
 .. option:: --default, -d
 
- On :subcmd:`avail` sub-command, display only the default version of each module
- name. Default version is the explicitly set default version or also the
- implicit default version if the configuration option ``implicit_default`` is enabled
- (see :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page for
- further details on implicit default version).
+ On :subcmd:`avail` sub-command, display only the default version of each
+ module name. Default version is the explicitly set default version or also
+ the implicit default version if the configuration option ``implicit_default``
+ is enabled (see :ref:`Locating Modulefiles` section in the
+ :ref:`modulefile(4)` man page for further details on implicit default
+ version).
 
  .. only:: html
 
@@ -271,8 +281,8 @@ switches are accepted:
 
 .. option:: --starts-with, -S
 
- On :subcmd:`avail` sub-command, return modules whose name starts with search query
- string.
+ On :subcmd:`avail` sub-command, return modules whose name starts with search
+ query string.
 
  .. only:: html
 
@@ -280,8 +290,8 @@ switches are accepted:
 
 .. option:: --contains, -C
 
- On :subcmd:`avail` sub-command, return modules whose fully qualified name contains
- search query string.
+ On :subcmd:`avail` sub-command, return modules whose fully qualified name
+ contains search query string.
 
  .. only:: html
 
@@ -289,9 +299,9 @@ switches are accepted:
 
 .. option:: --indepth
 
- On :subcmd:`avail` sub-command, include in search results the matching modulefiles
- and directories and recursively the modulefiles and directories contained in
- these matching directories.
+ On :subcmd:`avail` sub-command, include in search results the matching
+ modulefiles and directories and recursively the modulefiles and directories
+ contained in these matching directories.
 
  .. only:: html
 
@@ -299,9 +309,10 @@ switches are accepted:
 
 .. option:: --no-indepth
 
- On :subcmd:`avail` sub-command, limit search results to the matching modulefiles
- and directories found at the depth level expressed by the search query. Thus
- modulefiles contained in directories part of the result are excluded.
+ On :subcmd:`avail` sub-command, limit search results to the matching
+ modulefiles and directories found at the depth level expressed by the search
+ query. Thus modulefiles contained in directories part of the result are
+ excluded.
 
  .. only:: html
 
@@ -396,8 +407,8 @@ Module Sub-Commands
  List all available *modulefiles* in the current :envvar:`MODULEPATH`. All
  directories in the :envvar:`MODULEPATH` are recursively searched for files
  containing the *modulefile* magic cookie. If an argument is given, then
- each directory in the :envvar:`MODULEPATH` is searched for *modulefiles* whose
- pathname, symbolic version-name or alias match the argument. Argument
+ each directory in the :envvar:`MODULEPATH` is searched for *modulefiles*
+ whose pathname, symbolic version-name or alias match the argument. Argument
  may contain wildcard characters. Multiple versions of an application can
  be supported by creating a subdirectory for the application containing
  *modulefiles* for each version.
@@ -405,10 +416,11 @@ Module Sub-Commands
  Symbolic version-names and aliases found in the search are displayed in the
  result of this sub-command. Symbolic version-names are displayed next to
  the *modulefile* they are assigned to within parenthesis. Aliases are listed
- in the :envvar:`MODULEPATH` section where they have been defined. To distinguish
- aliases from *modulefiles* a ``@`` symbol is added within parenthesis
- next to their name. Aliases defined through a global or user specific
- module RC file are listed under the **global/user modulerc** section.
+ in the :envvar:`MODULEPATH` section where they have been defined. To
+ distinguish aliases from *modulefiles* a ``@`` symbol is added within
+ parenthesis next to their name. Aliases defined through a global or user
+ specific module RC file are listed under the **global/user modulerc**
+ section.
 
  When colored output is enabled and a specific graphical rendition is defined
  for module *default* version, the ``default`` symbol is omitted and instead
@@ -425,9 +437,10 @@ Module Sub-Commands
 .. subcmd:: aliases
 
  List all available symbolic version-names and aliases in the current
- :envvar:`MODULEPATH`.  All directories in the :envvar:`MODULEPATH` are recursively
- searched in the same manner than for the :subcmd:`avail` sub-command. Only the
- symbolic version-names and aliases found in the search are displayed.
+ :envvar:`MODULEPATH`.  All directories in the :envvar:`MODULEPATH` are
+ recursively searched in the same manner than for the :subcmd:`avail`
+ sub-command. Only the symbolic version-names and aliases found in the search
+ are displayed.
 
  .. only:: html
 
@@ -439,9 +452,9 @@ Module Sub-Commands
  variable.  The ``--append`` flag will append the *directory* to
  :envvar:`MODULEPATH`.
 
- Reference counter environment variable :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>` is
- also set to increase the number of times *directory* has been added to
- :envvar:`MODULEPATH`.
+ Reference counter environment variable
+ :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>` is also set to increase the
+ number of times *directory* has been added to :envvar:`MODULEPATH`.
 
 .. subcmd:: unuse directory...
 
@@ -449,12 +462,12 @@ Module Sub-Commands
  variable if reference counter of these *directories* is equal to 1
  or unknown.
 
- Reference counter of *directory* in :envvar:`MODULEPATH` denotes the number of
- times *directory* has been enabled. When attempting to remove *directory*
- from :envvar:`MODULEPATH`, reference counter variable :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>`
- is checked and *directory* is removed only if its relative counter is
- equal to 1 or not defined. Otherwise *directory* is kept and reference
- counter is decreased by 1.
+ Reference counter of *directory* in :envvar:`MODULEPATH` denotes the number
+ of times *directory* has been enabled. When attempting to remove *directory*
+ from :envvar:`MODULEPATH`, reference counter variable
+ :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>` is checked and *directory* is
+ removed only if its relative counter is equal to 1 or not defined. Otherwise
+ *directory* is kept and reference counter is decreased by 1.
 
 .. subcmd:: refresh
 
@@ -465,8 +478,8 @@ Module Sub-Commands
  Unload then load all loaded *modulefiles*.
 
  No unload then load is performed and an error is returned if the loaded
- *modulefiles* have unsatisfied constraint corresponding to the :mfcmd:`prereq`
- and :mfcmd:`conflict` they declare.
+ *modulefiles* have unsatisfied constraint corresponding to the
+ :mfcmd:`prereq` and :mfcmd:`conflict` they declare.
 
  .. only:: html
 
@@ -479,8 +492,9 @@ Module Sub-Commands
 .. subcmd:: clear [-f]
 
  Force the Modules package to believe that no modules are currently loaded. A
- confirmation is requested if command-line switch :option:`-f` (or :option:`--force`) is not
- passed. Typed confirmation should equal to ``yes`` or ``y`` in order to proceed.
+ confirmation is requested if command-line switch :option:`-f` (or
+ :option:`--force`) is not passed. Typed confirmation should equal to ``yes``
+ or ``y`` in order to proceed.
 
  .. only:: html
 
@@ -520,10 +534,10 @@ Module Sub-Commands
 
 .. subcmd:: search string
 
- Seeks through the :mfcmd:`module-whatis` informations of all *modulefiles* for the
- specified *string*. All *module-whatis* informations matching the *string* in
- a case insensitive manner will be displayed. *string* may contain wildcard
- characters.
+ Seeks through the :mfcmd:`module-whatis` informations of all *modulefiles*
+ for the specified *string*. All *module-whatis* informations matching the
+ *string* in a case insensitive manner will be displayed. *string* may contain
+ wildcard characters.
 
  .. only:: html
 
@@ -546,26 +560,26 @@ Module Sub-Commands
 
 .. subcmd:: save [collection]
 
- Record the currently set :envvar:`MODULEPATH` directory list and the currently
- loaded *modulefiles* in a *collection* file under the user's collection
- directory :file:`$HOME/.module`. If *collection* name is not specified, then
- it is assumed to be the ``default`` collection. If *collection* is a fully
- qualified path, it is saved at this location rather than under the user's
- collection directory.
+ Record the currently set :envvar:`MODULEPATH` directory list and the
+ currently loaded *modulefiles* in a *collection* file under the user's
+ collection directory :file:`$HOME/.module`. If *collection* name is not
+ specified, then it is assumed to be the ``default`` collection. If
+ *collection* is a fully qualified path, it is saved at this location rather
+ than under the user's collection directory.
 
- If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
- of this variable will be appended to the *collection* file name.
+ If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the
+ value of this variable will be appended to the *collection* file name.
 
  By default, if a loaded modulefile corresponds to the explicitly defined
- default module version, the bare module name is recorded. If the configuration
- option ``implicit_default`` is enabled, the bare module name is also recorded
- for the implicit default module version. If
- :envvar:`MODULES_COLLECTION_PIN_VERSION` is set to ``1``, module version is always
- recorded even if it is the default version.
+ default module version, the bare module name is recorded. If the
+ configuration option ``implicit_default`` is enabled, the bare module name is
+ also recorded for the implicit default module version. If
+ :envvar:`MODULES_COLLECTION_PIN_VERSION` is set to ``1``, module version is
+ always recorded even if it is the default version.
 
  No *collection* is recorded and an error is returned if the loaded
- *modulefiles* have unsatisfied constraint corresponding to the :mfcmd:`prereq`
- and :mfcmd:`conflict` they declare.
+ *modulefiles* have unsatisfied constraint corresponding to the
+ :mfcmd:`prereq` and :mfcmd:`conflict` they declare.
 
  .. only:: html
 
@@ -586,13 +600,14 @@ Module Sub-Commands
  loaded *modulefiles* lists saved in this *collection* file. The order
  of the paths and modulefiles set in *collection* is preserved when
  restoring. It means that currently loaded modules are unloaded to get
- the same :envvar:`LOADEDMODULES` root than collection and currently used module
- paths are unused to get the same :envvar:`MODULEPATH` root. Then missing module
- paths are used and missing modulefiles are loaded.
+ the same :envvar:`LOADEDMODULES` root than collection and currently used
+ module paths are unused to get the same :envvar:`MODULEPATH` root. Then
+ missing module paths are used and missing modulefiles are loaded.
 
  If a module, without a default version explicitly defined, is recorded in a
  *collection* by its bare name: loading this module when restoring the
- collection will fail if the configuration option ``implicit_default`` is disabled.
+ collection will fail if the configuration option ``implicit_default`` is
+ disabled.
 
  .. only:: html
 
@@ -602,8 +617,9 @@ Module Sub-Commands
 
  Delete the *collection* file under the user's collection directory. If
  *collection* name is not specified, then it is assumed to be the *default*
- collection. If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to
- the value of this variable will be appended to the *collection* file name.
+ collection. If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix
+ equivalent to the value of this variable will be appended to the *collection*
+ file name.
 
  .. only:: html
 
@@ -614,9 +630,9 @@ Module Sub-Commands
  Display the content of *collection*. If *collection* name is not specified,
  then it is assumed to be the *default* collection. If *collection* is a
  fully qualified path, this location is displayed rather than a collection
- file under the user's collection directory. If :envvar:`MODULES_COLLECTION_TARGET`
- is set, a suffix equivalent to the value of this variable will be appended
- to the *collection* file name.
+ file under the user's collection directory. If
+ :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
+ of this variable will be appended to the *collection* file name.
 
  .. only:: html
 
@@ -643,7 +659,8 @@ Module Sub-Commands
 
  TENEX C Shell
 
-  :file:`.modules`, :file:`.tcshrc`, :file:`.cshrc`, :file:`.csh_variables` and :file:`.login`
+  :file:`.modules`, :file:`.tcshrc`, :file:`.cshrc`, :file:`.csh_variables`
+  and :file:`.login`
 
  Bourne and Korn Shells
 
@@ -651,7 +668,8 @@ Module Sub-Commands
 
  GNU Bourne Again Shell
 
-  :file:`.modules`, :file:`.bash_profile`, :file:`.bash_login`, :file:`.profile` and :file:`.bashrc`
+  :file:`.modules`, :file:`.bash_profile`, :file:`.bash_login`,
+  :file:`.profile` and :file:`.bashrc`
 
  Z Shell
 
@@ -664,8 +682,9 @@ Module Sub-Commands
  If a ``module load`` line is found in any of these files, the *modulefiles*
  are appended to any existing list of *modulefiles*. The ``module load``
  line must be located in at least one of the files listed above for any of
- the :subcmd:`init<initadd>` sub-commands to work properly. If the ``module load`` line is
- found in multiple shell initialization files, all of the lines are changed.
+ the :subcmd:`init<initadd>` sub-commands to work properly. If the
+ ``module load`` line is found in multiple shell initialization files, all of
+ the lines are changed.
 
 .. subcmd:: initprepend modulefile...
 
@@ -715,8 +734,8 @@ Module Sub-Commands
 .. subcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Append *value* to environment *variable*. The *variable* is a colon, or
- *delimiter*, separated list. See :mfcmd:`append-path` in the :ref:`modulefile(4)`
- man page for further explanation.
+ *delimiter*, separated list. See :mfcmd:`append-path` in the
+ :ref:`modulefile(4)` man page for further explanation.
 
  .. only:: html
 
@@ -725,8 +744,8 @@ Module Sub-Commands
 .. subcmd:: prepend-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Prepend *value* to environment *variable*. The *variable* is a colon, or
- *delimiter*, separated list. See :mfcmd:`prepend-path` in the :ref:`modulefile(4)`
- man page for further explanation.
+ *delimiter*, separated list. See :mfcmd:`prepend-path` in the
+ :ref:`modulefile(4)` man page for further explanation.
 
  .. only:: html
 
@@ -746,8 +765,8 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *modulefiles* has been loaded or if
  any *modulefile* is loaded in case no argument is provided. Returns a false
- value otherwise. See :mfcmd:`is-loaded` in the :ref:`modulefile(4)` man page for
- further explanation.
+ value otherwise. See :mfcmd:`is-loaded` in the :ref:`modulefile(4)` man page
+ for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -761,8 +780,8 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *collections* exists or if any
  *collection* exists in case no argument is provided. Returns a false value
- otherwise. See :mfcmd:`is-saved` in the :ref:`modulefile(4)` man page for further
- explanation.
+ otherwise. See :mfcmd:`is-saved` in the :ref:`modulefile(4)` man page for
+ further explanation.
 
  .. only:: html
 
@@ -782,8 +801,8 @@ Module Sub-Commands
 .. subcmd:: is-avail modulefile...
 
  Returns a true value if any of the listed *modulefiles* exists in enabled
- :envvar:`MODULEPATH`. Returns a false value otherwise. See :mfcmd:`is-avail` in the
- :ref:`modulefile(4)` man page for further explanation.
+ :envvar:`MODULEPATH`. Returns a false value otherwise. See :mfcmd:`is-avail`
+ in the :ref:`modulefile(4)` man page for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -797,8 +816,8 @@ Module Sub-Commands
 
  Returns the names of currently loaded modules matching passed *modulefile*.
  Returns an empty string if passed *modulefile* does not match any loaded
- modules. See :mfcmd:`module-info loaded<module-info>` in the :ref:`modulefile(4)` man page for
- further explanation.
+ modules. See :mfcmd:`module-info loaded<module-info>` in the
+ :ref:`modulefile(4)` man page for further explanation.
 
  .. only:: html
 
@@ -806,11 +825,11 @@ Module Sub-Commands
 
 .. subcmd:: config [--dump-state|name [value]|--reset name]
 
- Gets or sets :file:`modulecmd.tcl` options. Reports the currently set value of
- passed option *name* or all existing options if no *name* passed. If a *name*
- and a *value* are provided, the value of option *name* is set to *value*. If
- command-line switch ``--reset`` is passed in addition to a *name*, overridden
- value for option *name* is cleared.
+ Gets or sets :file:`modulecmd.tcl` options. Reports the currently set value
+ of passed option *name* or all existing options if no *name* passed. If a
+ *name* and a *value* are provided, the value of option *name* is set to
+ *value*. If command-line switch ``--reset`` is passed in addition to a
+ *name*, overridden value for option *name* is cleared.
 
  When a reported option value differs from default value a mention is added
  to indicate whether the overridden value is coming from a command-line switch
@@ -820,9 +839,9 @@ Module Sub-Commands
  If no value is currently set for an option *name*, the mention ``<undef>`` is
  reported.
 
- When command-line switch ``--dump-state`` is passed, current :file:`modulecmd.tcl`
- state and Modules-related environment variables are reported in addition to
- currently set :file:`modulecmd.tcl` options.
+ When command-line switch ``--dump-state`` is passed, current
+ :file:`modulecmd.tcl` state and Modules-related environment variables are
+ reported in addition to currently set :file:`modulecmd.tcl` options.
 
  Existing option *names* are:
 
@@ -831,12 +850,12 @@ Module Sub-Commands
    :envvar:`MODULES_ADVANCED_VERSION_SPEC` when set
  * ``auto_handling``: automated module handling mode (defines
    :envvar:`MODULES_AUTO_HANDLING`)
- * ``avail_indepth``: :subcmd:`avail` sub-command in depth search mode (defines
-   :envvar:`MODULES_AVAIL_INDEPTH`)
- * ``avail_report_dir_sym``: display symbolic versions targeting directories on
-   :subcmd:`avail` sub-command
- * ``avail_report_mfile_sym``: display symbolic versions targeting modulefiles on
-   :subcmd:`avail` sub-command
+ * ``avail_indepth``: :subcmd:`avail` sub-command in depth search mode
+   (defines :envvar:`MODULES_AVAIL_INDEPTH`)
+ * ``avail_report_dir_sym``: display symbolic versions targeting directories
+   on :subcmd:`avail` sub-command
+ * ``avail_report_mfile_sym``: display symbolic versions targeting modulefiles
+   on :subcmd:`avail` sub-command
  * ``collection_pin_version``: register exact modulefile version in collection
    (defines :envvar:`MODULES_COLLECTION_PIN_VERSION`)
  * ``collection_target``: collection target which is valid for current system
@@ -847,8 +866,8 @@ Module Sub-Commands
  * ``contact``: modulefile contact address (defines :envvar:`MODULECONTACT`)
  * ``extended_default``: allow partial module version specification (defines
    :envvar:`MODULES_EXTENDED_DEFAULT`)
- * ``extra_siteconfig``: additional site-specific configuration script location
-   (defines :envvar:`MODULES_SITECONFIG`)
+ * ``extra_siteconfig``: additional site-specific configuration script
+   location (defines :envvar:`MODULES_SITECONFIG`)
  * ``home``: location of Modules package master directory (defines
    :envvar:`MODULESHOME`)
  * ``icase``: enable case insensitive match (defines :envvar:`MODULES_ICASE`)
@@ -856,28 +875,33 @@ Module Sub-Commands
  * ``implicit_default``: set an implicit default version for modules (defines
    :envvar:`MODULES_IMPLICIT_DEFAULT`)
  * ``locked_configs``: configuration options that cannot be superseded
- * ``pager``: text viewer to paginate message output (defines :envvar:`MODULES_PAGER`)
- * ``rcfile``: global run-command file location (defines :envvar:`MODULERCFILE`)
+ * ``pager``: text viewer to paginate message output (defines
+   :envvar:`MODULES_PAGER`)
+ * ``rcfile``: global run-command file location (defines
+   :envvar:`MODULERCFILE`)
  * ``run_quarantine``: environment variables to indirectly pass to
    :file:`modulecmd.tcl` (defines :envvar:`MODULES_RUN_QUARANTINE`)
- * ``silent_shell_debug``: disablement of shell debugging property for the module
-   command (defines :envvar:`MODULES_SILENT_SHELL_DEBUG`)
- * ``search_match``: module search match style (defines :envvar:`MODULES_SEARCH_MATCH`)
+ * ``silent_shell_debug``: disablement of shell debugging property for the
+   module command (defines :envvar:`MODULES_SILENT_SHELL_DEBUG`)
+ * ``search_match``: module search match style (defines
+   :envvar:`MODULES_SEARCH_MATCH`)
  * ``set_shell_startup``: ensure module command definition by setting shell
    startup file (defines :envvar:`MODULES_SET_SHELL_STARTUP`)
  * ``siteconfig``: primary site-specific configuration script location
  * ``tcl_ext_lib``: Modules Tcl extension library location
  * ``term_background``: terminal background color kind (defines
    :envvar:`MODULES_TERM_BACKGROUND`)
- * ``unload_match_order``: unload firstly loaded or lastly loaded module matching
-   request (defines :envvar:`MODULES_UNLOAD_MATCH_ORDER`)
- * ``verbosity``: module command verbosity level (defines :envvar:`MODULES_VERBOSITY`)
- * ``wa_277``: workaround for Tcsh history issue (defines :envvar:`MODULES_WA_277`)
+ * ``unload_match_order``: unload firstly loaded or lastly loaded module
+   matching request (defines :envvar:`MODULES_UNLOAD_MATCH_ORDER`)
+ * ``verbosity``: module command verbosity level (defines
+   :envvar:`MODULES_VERBOSITY`)
+ * ``wa_277``: workaround for Tcsh history issue (defines
+   :envvar:`MODULES_WA_277`)
 
-The options ``avail_report_dir_sym``, ``avail_report_mfile_sym``, ``ignored_dirs``,
-``locked_configs``, ``siteconfig`` and ``tcl_ext_lib`` cannot be altered. Moreover
-all options referred in ``locked_configs`` value are locked, thus they cannot be
-altered.
+ The options ``avail_report_dir_sym``, ``avail_report_mfile_sym``,
+ ``ignored_dirs``, ``locked_configs``, ``siteconfig`` and ``tcl_ext_lib``
+ cannot be altered. Moreover all options referred in ``locked_configs`` value
+ are locked, thus they cannot be altered.
 
  .. only:: html
 
@@ -893,18 +917,18 @@ statements. Thus the effect a *modulefile* will have on the environment
 may change depending upon the current state of the environment.
 
 Environment variables are unset when unloading a *modulefile*. Thus, it is
-possible to :subcmd:`load` a *modulefile* and then :subcmd:`unload` it without having
-the environment variables return to their prior state.
+possible to :subcmd:`load` a *modulefile* and then :subcmd:`unload` it without
+having the environment variables return to their prior state.
 
 
 Advanced module version specifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the advanced module version specifiers mechanism is enabled (see
-:envvar:`MODULES_ADVANCED_VERSION_SPEC`), the specification of modulefile passed on
-Modules sub-commands changes. After the module name a version constraint
-prefixed by the ``@`` character may be added. It could be directly appended to
-the module name or separated from it with a space character.
+:envvar:`MODULES_ADVANCED_VERSION_SPEC`), the specification of modulefile
+passed on Modules sub-commands changes. After the module name a version
+constraint prefixed by the ``@`` character may be added. It could be directly
+appended to the module name or separated from it with a space character.
 
 Constraints can be expressed to refine the selection of module version to:
 
@@ -921,9 +945,9 @@ Constraints can be expressed to refine the selection of module version to:
 
 Advanced specification of single version or list of versions may benefit from
 the activation of the extended default mechanism (see
-:envvar:`MODULES_EXTENDED_DEFAULT`) to use an abbreviated notation like ``@1`` to
-refer to more precise version numbers like ``1.2.3``. Range of versions on its
-side natively handles abbreviated versions.
+:envvar:`MODULES_EXTENDED_DEFAULT`) to use an abbreviated notation like ``@1``
+to refer to more precise version numbers like ``1.2.3``. Range of versions on
+its side natively handles abbreviated versions.
 
 In order to be specified in a range of versions or compared to a range of
 versions, the version major element should corresponds to a number. For
@@ -935,28 +959,28 @@ comparison.
 Collections
 ^^^^^^^^^^^
 
-Collections describe a sequence of :subcmd:`module use<use>` then :subcmd:`module load<load>`
-commands that are interpreted by :file:`modulecmd.tcl` to set the user
-environment as described by this sequence. When a collection is activated,
-with the :subcmd:`restore` sub-command, module paths and loaded modules are
-unused or unloaded if they are not part or if they are not ordered the
-same way as in the collection.
+Collections describe a sequence of :subcmd:`module use<use>` then
+:subcmd:`module load<load>` commands that are interpreted by
+:file:`modulecmd.tcl` to set the user environment as described by this
+sequence. When a collection is activated, with the :subcmd:`restore`
+sub-command, module paths and loaded modules are unused or unloaded if they
+are not part or if they are not ordered the same way as in the collection.
 
-Collections are generated by the :subcmd:`save` sub-command that dumps the current
-user environment state in terms of module paths and loaded modules. By
+Collections are generated by the :subcmd:`save` sub-command that dumps the
+current user environment state in terms of module paths and loaded modules. By
 default collections are saved under the :file:`$HOME/.module` directory.
 
 Collections may be valid for a given target if they are suffixed. In this
 case these collections can only be restored if their suffix correspond to
-the current value of the :envvar:`MODULES_COLLECTION_TARGET` environment variable
-(see the dedicated section of this topic below).
+the current value of the :envvar:`MODULES_COLLECTION_TARGET` environment
+variable (see the dedicated section of this topic below).
 
 
 EXIT STATUS
 -----------
 
-The :command:`module` command exits with ``0`` if its execution succeed. Otherwise
-``1`` is returned.
+The :command:`module` command exits with ``0`` if its execution succeed.
+Otherwise ``1`` is returned.
 
 
 ENVIRONMENT
@@ -980,15 +1004,15 @@ ENVIRONMENT
  The path that the :command:`module` command searches when looking for
  *modulefiles*. Typically, it is set to the master *modulefiles* directory,
  |file modulefilesdir|, by the initialization script. :envvar:`MODULEPATH`
- can be set using :subcmd:`module use<use>` or by the module initialization script
- to search group or personal *modulefile* directories before or after the
- master *modulefile* directory.
+ can be set using :subcmd:`module use<use>` or by the module initialization
+ script to search group or personal *modulefile* directories before or after
+ the master *modulefile* directory.
 
  Path elements registered in the :envvar:`MODULEPATH` environment variable may
  contain reference to environment variables which are converted to their
  corresponding value by :command:`module` command each time it looks at the
- :envvar:`MODULEPATH` value. If an environment variable referred in a path element
- is not defined, its reference is converted to an empty string.
+ :envvar:`MODULEPATH` value. If an environment variable referred in a path
+ element is not defined, its reference is converted to an empty string.
 
 .. envvar:: MODULERCFILE
 
@@ -1008,9 +1032,10 @@ ENVIRONMENT
  module version specifiers.
 
  Advanced module version specifiers enablement is defined in the following
- order of preference: :envvar:`MODULES_ADVANCED_VERSION_SPEC` environment variable
- then the default set in :file:`modulecmd.tcl` script configuration. Which means
- :envvar:`MODULES_ADVANCED_VERSION_SPEC` overrides default configuration.
+ order of preference: :envvar:`MODULES_ADVANCED_VERSION_SPEC` environment
+ variable then the default set in :file:`modulecmd.tcl` script configuration.
+ Which means :envvar:`MODULES_ADVANCED_VERSION_SPEC` overrides default
+ configuration.
 
  .. only:: html
 
@@ -1025,48 +1050,50 @@ ENVIRONMENT
  loading or unloading a *modulefile* to satisfy the constraints it declares.
  When loading a *modulefile*, following actions are triggered:
 
- * Requirement Load: load of the *modulefiles* declared as a :mfcmd:`prereq` of
-   the loading *modulefile*.
+ * Requirement Load: load of the *modulefiles* declared as a :mfcmd:`prereq`
+   of the loading *modulefile*.
 
- * Dependent Reload: reload of the modulefiles declaring a :mfcmd:`prereq` onto
-   loaded *modulefile* or declaring a :mfcmd:`prereq` onto a *modulefile* part of
-   this reloading batch.
+ * Dependent Reload: reload of the modulefiles declaring a :mfcmd:`prereq`
+   onto loaded *modulefile* or declaring a :mfcmd:`prereq` onto a *modulefile*
+   part of this reloading batch.
 
  When unloading a *modulefile*, following actions are triggered:
 
  * Dependent Unload: unload of the modulefiles declaring a non-optional
-   :mfcmd:`prereq` onto unloaded modulefile or declaring a non-optional :mfcmd:`prereq`
-   onto a modulefile part of this unloading batch. A :mfcmd:`prereq` modulefile is
-   considered optional if the :mfcmd:`prereq` definition order is made of multiple
-   modulefiles and at least one alternative modulefile is loaded.
+   :mfcmd:`prereq` onto unloaded modulefile or declaring a non-optional
+   :mfcmd:`prereq` onto a modulefile part of this unloading batch. A
+   :mfcmd:`prereq` modulefile is considered optional if the :mfcmd:`prereq`
+   definition order is made of multiple modulefiles and at least one
+   alternative modulefile is loaded.
 
- * Useless Requirement Unload: unload of the :mfcmd:`prereq` modulefiles that have
-   been automatically loaded for either the unloaded modulefile, an unloaded
-   dependent modulefile or a modulefile part of this useless requirement
-   unloading batch. Modulefiles are added to this unloading batch only if
-   they are not required by any other loaded modulefiles.
+ * Useless Requirement Unload: unload of the :mfcmd:`prereq` modulefiles that
+   have been automatically loaded for either the unloaded modulefile, an
+   unloaded dependent modulefile or a modulefile part of this useless
+   requirement unloading batch. Modulefiles are added to this unloading batch
+   only if they are not required by any other loaded modulefiles.
 
- * Dependent Reload: reload of the modulefiles declaring a :mfcmd:`conflict` or an
-   optional :mfcmd:`prereq` onto either the unloaded modulefile, an unloaded
-   dependent or an unloaded useless requirement or declaring a :mfcmd:`prereq` onto
-   a modulefile part of this reloading batch.
+ * Dependent Reload: reload of the modulefiles declaring a :mfcmd:`conflict`
+   or an optional :mfcmd:`prereq` onto either the unloaded modulefile, an
+   unloaded dependent or an unloaded useless requirement or declaring a
+   :mfcmd:`prereq` onto a modulefile part of this reloading batch.
 
  In case a loaded *modulefile* has some of its declared constraints
  unsatisfied (pre-required modulefile not loaded or conflicting modulefile
  loaded for instance), this loaded *modulefile* is excluded from the automatic
  reload actions described above.
 
- For the specific case of the :subcmd:`switch` sub-command, where a modulefile is
- unloaded to then load another modulefile. Dependent modulefiles to Unload are
- merged into the Dependent modulefiles to Reload that are reloaded after the
- load of the switched-to modulefile.
+ For the specific case of the :subcmd:`switch` sub-command, where a modulefile
+ is unloaded to then load another modulefile. Dependent modulefiles to Unload
+ are merged into the Dependent modulefiles to Reload that are reloaded after
+ the load of the switched-to modulefile.
 
  Automated module handling mode enablement is defined in the following order
  of preference: :option:`--auto`/:option:`--no-auto` command line switches,
- then :envvar:`MODULES_AUTO_HANDLING` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AUTO_HANDLING`
- overrides default configuration and :option:`--auto`/:option:`--no-auto` command line
- switches override every other ways to enable or disable this mode.
+ then :envvar:`MODULES_AUTO_HANDLING` environment variable, then the default
+ set in :file:`modulecmd.tcl` script configuration. Which means
+ :envvar:`MODULES_AUTO_HANDLING` overrides default configuration and
+ :option:`--auto`/:option:`--no-auto` command line switches override every
+ other ways to enable or disable this mode.
 
  .. only:: html
 
@@ -1074,21 +1101,22 @@ ENVIRONMENT
 
 .. envvar:: MODULES_AVAIL_INDEPTH
 
- If set to ``1``, enable in depth search results for :subcmd:`avail` sub-command. If
- set to ``0`` disable :subcmd:`avail` sub-command in depth mode. Other values are
- ignored.
+ If set to ``1``, enable in depth search results for :subcmd:`avail`
+ sub-command. If set to ``0`` disable :subcmd:`avail` sub-command in depth
+ mode. Other values are ignored.
 
  When in depth mode is enabled, modulefiles and directories contained in
  directories matching search query are also included in search results. When
  disabled these modulefiles and directories contained in matching directories
  are excluded.
 
- :subcmd:`avail` sub-command in depth mode enablement is defined in the following
- order of preference: :option:`--indepth`/:option:`--no-indepth` command line switches,
- then :envvar:`MODULES_AVAIL_INDEPTH` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AVAIL_INDEPTH`
- overrides default configuration and :option:`--indepth`/:option:`--no-indepth` command
- line switches override every other ways to enable or disable this mode.
+ :subcmd:`avail` sub-command in depth mode enablement is defined in the
+ following order of preference: :option:`--indepth`/:option:`--no-indepth`
+ command line switches, then :envvar:`MODULES_AVAIL_INDEPTH` environment
+ variable, then the default set in :file:`modulecmd.tcl` script configuration.
+ Which means :envvar:`MODULES_AVAIL_INDEPTH` overrides default configuration
+ and :option:`--indepth`/:option:`--no-indepth` command line switches override
+ every other ways to enable or disable this mode.
 
  .. only:: html
 
@@ -1120,19 +1148,20 @@ ENVIRONMENT
 
  Collection directory may sometimes be shared on multiple machines which may
  use different modules setup. For instance modules users may access with the
- same :envvar:`HOME` directory multiple systems using different OS versions. When
- it happens a collection made on machine 1 may be erroneous on machine 2.
+ same :envvar:`HOME` directory multiple systems using different OS versions.
+ When it happens a collection made on machine 1 may be erroneous on machine 2.
 
  When a target is set, only the collections made for that target are
- available to the :subcmd:`restore`, :subcmd:`savelist`, :subcmd:`saveshow` and :subcmd:`saverm`
- sub-commands. Saving a collection registers the target footprint by suffixing
- the collection filename with ``.$MODULES_COLLECTION_TARGET``. The collection
- target is not involved when collection is specified as file path on the
- :subcmd:`saveshow`, :subcmd:`restore` and :subcmd:`save` sub-commands.
+ available to the :subcmd:`restore`, :subcmd:`savelist`, :subcmd:`saveshow`
+ and :subcmd:`saverm` sub-commands. Saving a collection registers the target
+ footprint by suffixing the collection filename with
+ ``.$MODULES_COLLECTION_TARGET``. The collection target is not involved when
+ collection is specified as file path on the :subcmd:`saveshow`,
+ :subcmd:`restore` and :subcmd:`save` sub-commands.
 
  For example, the :envvar:`MODULES_COLLECTION_TARGET` variable may be set with
- results from commands like :command:`lsb_release`, :command:`hostname`, :command:`dnsdomainname`,
- etc.
+ results from commands like :command:`lsb_release`, :command:`hostname`,
+ :command:`dnsdomainname`, etc.
 
  .. only:: html
 
@@ -1147,19 +1176,21 @@ ENVIRONMENT
  error output channel is attached to a terminal.
 
  Colored output enablement is defined in the following order of preference:
- :option:`--color` command line switch, then :envvar:`MODULES_COLOR` environment variable,
- then :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables, then the
- default set in :file:`modulecmd.tcl` script configuration. Which means
- :envvar:`MODULES_COLOR` overrides default configuration and the
- :envvar:`CLICOLOR`/:envvar:`CLICOLOR_FORCE` variables. :option:`--color` command line switch
- overrides every other ways to enable or disable this mode.
+ :option:`--color` command line switch, then :envvar:`MODULES_COLOR`
+ environment variable, then :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE`
+ environment variables, then the default set in :file:`modulecmd.tcl` script
+ configuration. Which means :envvar:`MODULES_COLOR` overrides default
+ configuration and the :envvar:`CLICOLOR`/:envvar:`CLICOLOR_FORCE` variables.
+ :option:`--color` command line switch overrides every other ways to enable or
+ disable this mode.
 
- :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables are also honored to
- define color mode. The ``never`` mode is set if :envvar:`CLICOLOR` equals to ``0``.
- If :envvar:`CLICOLOR` is set to another value, it corresponds to the ``auto`` mode.
- The ``always`` mode is set if :envvar:`CLICOLOR_FORCE` is set to a value different
- than ``0``. Color mode set with these two variables is superseded by mode set
- with :envvar:`MODULES_COLOR` environment variable.
+ :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables are
+ also honored to define color mode. The ``never`` mode is set if
+ :envvar:`CLICOLOR` equals to ``0``. If :envvar:`CLICOLOR` is set to another
+ value, it corresponds to the ``auto`` mode. The ``always`` mode is set if
+ :envvar:`CLICOLOR_FORCE` is set to a value different than ``0``. Color mode
+ set with these two variables is superseded by mode set with
+ :envvar:`MODULES_COLOR` environment variable.
 
  .. only:: html
 
@@ -1173,20 +1204,20 @@ ENVIRONMENT
  :envvar:`LS_COLORS`.
 
  Output items are designated by keys. Items able to be colorized are:
- highlighted element (``hi``), debug information (``db``), tag separator (``se``);
- Error (``er``), warning (``wa``), module error (``me``) and info (``in``) message
- prefixes; Modulepath (``mp``), directory (``di``), module alias (``al``), module
- symbolic version (``sy``), module ``default`` version (``de``) and modulefile
- command (``cm``).
+ highlighted element (``hi``), debug information (``db``), tag separator
+ (``se``); Error (``er``), warning (``wa``), module error (``me``) and info
+ (``in``) message prefixes; Modulepath (``mp``), directory (``di``), module
+ alias (``al``), module symbolic version (``sy``), module ``default`` version
+ (``de``) and modulefile command (``cm``).
 
  See the Select Graphic Rendition (SGR) section in the documentation of the
  text terminal that is used for permitted values and their meaning as
  character attributes. These substring values are integers in decimal
  representation and can be concatenated with semicolons. Modules takes care of
  assembling the result into a complete SGR sequence (``\33[...m``). Common
- values to concatenate include ``1`` for bold, ``4`` for underline, ``30`` to ``37`` for
- foreground colors and ``90`` to ``97`` for 16-color mode foreground colors. See also
- https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
+ values to concatenate include ``1`` for bold, ``4`` for underline, ``30`` to
+ ``37`` for foreground colors and ``90`` to ``97`` for 16-color mode
+ foreground colors. See also https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
  for a complete SGR code reference.
 
  No graphical rendition will be applied to an output item that could normaly
@@ -1195,8 +1226,8 @@ ENVIRONMENT
 
  The color set is defined for Modules in the following order of preference:
  :envvar:`MODULES_COLORS` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_COLORS`
- overrides default configuration.
+ :file:`modulecmd.tcl` script configuration. Which means
+ :envvar:`MODULES_COLORS` overrides default configuration.
 
  .. only:: html
 
@@ -1211,9 +1242,10 @@ ENVIRONMENT
  ``mod/1.2.3``.
 
  In case multiple modulefiles match the specified module version and a single
- module has to be selected, the explicitly set default version is returned if it
- is part of matching modulefiles. Otherwise the implicit default among matching
- modulefiles is returned if defined (see :envvar:`MODULES_IMPLICIT_DEFAULT` section)
+ module has to be selected, the explicitly set default version is returned if
+ it is part of matching modulefiles. Otherwise the implicit default among
+ matching modulefiles is returned if defined (see
+ :envvar:`MODULES_IMPLICIT_DEFAULT` section)
 
  This environment variable supersedes the value of the configuration option
  ``extended_default`` set in :file:`modulecmd.tcl` script.
@@ -1226,19 +1258,20 @@ ENVIRONMENT
 
  When module specification are passed as argument to module sub-commands or
  modulefile Tcl commands, defines the case sensitiveness to apply to match
- them. When :envvar:`MODULES_ICASE` is set to ``never``, a case sensitive match is
- applied in any cases. When set to ``search``, a case insensitive match is
- applied to the :subcmd:`avail`, :subcmd:`whatis` and :subcmd:`paths` sub-commands. When set to
- ``always``, a case insensitive match is also applied to the other module
- sub-commands and modulefile Tcl commands for the module specification they
- receive as argument.
+ them. When :envvar:`MODULES_ICASE` is set to ``never``, a case sensitive
+ match is applied in any cases. When set to ``search``, a case insensitive
+ match is applied to the :subcmd:`avail`, :subcmd:`whatis` and :subcmd:`paths`
+ sub-commands. When set to ``always``, a case insensitive match is also
+ applied to the other module sub-commands and modulefile Tcl commands for the
+ module specification they receive as argument.
 
  Case sensitiveness behavior is defined in the following order of preference:
- :option:`--icase` command line switch, which corresponds to the ``always`` mode,
- then :envvar:`MODULES_ICASE` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_ICASE`
- overrides default configuration and :option:`--icase` command line switch overrides
- every other ways to set case sensitiveness behavior.
+ :option:`--icase` command line switch, which corresponds to the ``always``
+ mode, then :envvar:`MODULES_ICASE` environment variable, then the default set
+ in :file:`modulecmd.tcl` script configuration. Which means
+ :envvar:`MODULES_ICASE` overrides default configuration and :option:`--icase`
+ command line switch overrides every other ways to set case sensitiveness
+ behavior.
 
  .. only:: html
 
@@ -1254,23 +1287,24 @@ ENVIRONMENT
  be fully qualified (version should be specified in addition to its name) to
  get:
 
- * targeted by module :subcmd:`load`, :subcmd:`switch`, :subcmd:`display`, :subcmd:`help`, :subcmd:`test`
-   and :subcmd:`path` sub-commands.
+ * targeted by module :subcmd:`load`, :subcmd:`switch`, :subcmd:`display`,
+   :subcmd:`help`, :subcmd:`test` and :subcmd:`path` sub-commands.
 
  * restored from a collection, unless already loaded in collection-specified
    order.
 
  * automatically loaded by automated module handling mechanisms (see
-   :envvar:`MODULES_AUTO_HANDLING` section) when declared as module requirement,
-   with :mfcmd:`prereq` or :mfcmd:`module load<module>` modulefile commands.
+   :envvar:`MODULES_AUTO_HANDLING` section) when declared as module
+   requirement, with :mfcmd:`prereq` or :mfcmd:`module load<module>`
+   modulefile commands.
 
  An error is returned in the above situations if either no explicit or
  implicit default version is defined.
 
  This environment variable supersedes the value of the configuration option
- ``implicit_default`` set in :file:`modulecmd.tcl` script. This environment variable
- is ignored if ``implicit_default`` has been declared locked in ``locked_configs``
- configuration option.
+ ``implicit_default`` set in :file:`modulecmd.tcl` script. This environment
+ variable is ignored if ``implicit_default`` has been declared locked in
+ ``locked_configs`` configuration option.
 
  .. only:: html
 
@@ -1279,18 +1313,18 @@ ENVIRONMENT
 .. envvar:: MODULES_LMALTNAME
 
  A colon separated list of the alternative names set through
- :mfcmd:`module-version` and :mfcmd:`module-alias` statements corresponding to all
- loaded *modulefiles*. Each element in this list starts by the name of the
+ :mfcmd:`module-version` and :mfcmd:`module-alias` statements corresponding to
+ all loaded *modulefiles*. Each element in this list starts by the name of the
  loaded *modulefile* followed by all alternative names resolving to it. The
  loaded modulefile and its alternative names are separated by the ampersand
  character.
 
- This environment variable is intended for :command:`module` command internal use to
- get knowledge of the alternative names matching loaded *modulefiles* in order
- to keep environment consistent when conflicts or pre-requirements are set
- over these alternative designations. It also helps to find a match after
- *modulefiles* being loaded when :subcmd:`unload`, :subcmd:`is-loaded` or :subcmd:`info-loaded`
- actions are run over these names.
+ This environment variable is intended for :command:`module` command internal
+ use to get knowledge of the alternative names matching loaded *modulefiles*
+ in order to keep environment consistent when conflicts or pre-requirements
+ are set over these alternative designations. It also helps to find a match
+ after *modulefiles* being loaded when :subcmd:`unload`, :subcmd:`is-loaded`
+ or :subcmd:`info-loaded` actions are run over these names.
 
  .. only:: html
 
@@ -1298,11 +1332,11 @@ ENVIRONMENT
 
 .. envvar:: MODULES_LMCONFLICT
 
- A colon separated list of the :mfcmd:`conflict` statements defined by all loaded
- *modulefiles*. Each element in this list starts by the name of the loaded
- *modulefile* declaring the conflict followed by the name of all modulefiles
- it declares a conflict with. These loaded modulefiles and conflicting
- modulefile names are separated by the ampersand character.
+ A colon separated list of the :mfcmd:`conflict` statements defined by all
+ loaded *modulefiles*. Each element in this list starts by the name of the
+ loaded *modulefile* declaring the conflict followed by the name of all
+ modulefiles it declares a conflict with. These loaded modulefiles and
+ conflicting modulefile names are separated by the ampersand character.
 
  This environment variable is intended for :command:`module` command internal
  use to get knowledge of the conflicts declared by the loaded *modulefiles*
@@ -1328,13 +1362,13 @@ ENVIRONMENT
 
 .. envvar:: MODULES_LMPREREQ
 
- A colon separated list of the :mfcmd:`prereq` statements defined by all loaded
- *modulefiles*. Each element in this list starts by the name of the loaded
- *modulefile* declaring the pre-requirement followed by the name of all
+ A colon separated list of the :mfcmd:`prereq` statements defined by all
+ loaded *modulefiles*. Each element in this list starts by the name of the
+ loaded *modulefile* declaring the pre-requirement followed by the name of all
  modulefiles it declares a :mfcmd:`prereq` with. These loaded modulefiles and
  pre-required modulefile names are separated by the ampersand character. When
- a :mfcmd:`prereq` statement is composed of multiple modulefiles, these modulefile
- names are separated by the pipe character.
+ a :mfcmd:`prereq` statement is composed of multiple modulefiles, these
+ modulefile names are separated by the pipe character.
 
  This environment variable is intended for :command:`module` command internal
  use to get knowledge of the pre-requirement declared by the loaded
@@ -1352,9 +1386,9 @@ ENVIRONMENT
  command name or path eventually followed by command-line options.
 
  Paging command and options are defined for Modules in the following order of
- preference: :envvar:`MODULES_PAGER` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_PAGER`
- overrides default configuration.
+ preference: :envvar:`MODULES_PAGER` environment variable, then the default
+ set in :file:`modulecmd.tcl` script configuration. Which means
+ :envvar:`MODULES_PAGER` overrides default configuration.
 
  If :envvar:`MODULES_PAGER` variable is set to an empty string or to the value
  ``cat``, pager will not be launched.
@@ -1365,8 +1399,9 @@ ENVIRONMENT
 
 .. envvar:: MODULES_RUNENV_<VAR>
 
- Value to set to environment variable :envvar:`<VAR>` for :file:`modulecmd.tcl` run-time
- execution if :envvar:`<VAR>` is referred in :envvar:`MODULES_RUN_QUARANTINE`.
+ Value to set to environment variable :envvar:`<VAR>` for
+ :file:`modulecmd.tcl` run-time execution if :envvar:`<VAR>` is referred in
+ :envvar:`MODULES_RUN_QUARANTINE`.
 
  .. only:: html
 
@@ -1378,9 +1413,10 @@ ENVIRONMENT
  indirectly to :file:`modulecmd.tcl` to protect its run-time environment from
  side-effect coming from their current definition.
 
- Each variable found in :envvar:`MODULES_RUN_QUARANTINE` will have its value emptied
- or set to the value of the corresponding :envvar:`MODULES_RUNENV_<VAR>` variable
- when defining :file:`modulecmd.tcl` run-time environment.
+ Each variable found in :envvar:`MODULES_RUN_QUARANTINE` will have its value
+ emptied or set to the value of the corresponding
+ :envvar:`MODULES_RUNENV_\<VAR\>` variable when defining :file:`modulecmd.tcl`
+ run-time environment.
 
  Original values of these environment variables set in quarantine are passed
  to :file:`modulecmd.tcl` via :envvar:`<VAR>_modquar` variables.
@@ -1391,18 +1427,19 @@ ENVIRONMENT
 
 .. envvar:: MODULES_SEARCH_MATCH
 
- When searching for modules with :subcmd:`avail` sub-command, defines the way query
- string should match against available module names. With ``starts_with``
- value, returned modules are those whose name begins by search query string.
- When set to ``contains``, any modules whose fully qualified name contains
- search query string are returned.
+ When searching for modules with :subcmd:`avail` sub-command, defines the way
+ query string should match against available module names. With
+ ``starts_with`` value, returned modules are those whose name begins by search
+ query string. When set to ``contains``, any modules whose fully qualified
+ name contains search query string are returned.
 
  Module search match style is defined in the following order of preference:
  :option:`--starts-with` and :option:`--contains` command line switches, then
  :envvar:`MODULES_SEARCH_MATCH` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_SEARCH_MATCH`
- overrides default configuration and :option:`--starts-with`/:option:`--contains` command
- line switches override every other ways to set search match style.
+ :file:`modulecmd.tcl` script configuration. Which means
+ :envvar:`MODULES_SEARCH_MATCH` overrides default configuration and
+ :option:`--starts-with`/:option:`--contains` command line switches override
+ every other ways to set search match style.
 
  .. only:: html
 
@@ -1413,8 +1450,8 @@ ENVIRONMENT
  If set to ``1``, defines when :command:`module` command initializes the shell
  startup file to ensure that the :command:`module` command is still defined in
  sub-shells. Setting shell startup file means defining the :envvar:`ENV` and
- :envvar:`BASH_ENV` environment variable to the Modules bourne shell initialization
- script. If set to ``0``, shell startup file is not defined.
+ :envvar:`BASH_ENV` environment variable to the Modules bourne shell
+ initialization script. If set to ``0``, shell startup file is not defined.
 
  .. only:: html
 
@@ -1422,8 +1459,8 @@ ENVIRONMENT
 
 .. envvar:: MODULES_SILENT_SHELL_DEBUG
 
- If set to ``1``, disable any ``xtrace`` or ``verbose`` debugging property set on
- current shell session for the duration of either the module command or the
+ If set to ``1``, disable any ``xtrace`` or ``verbose`` debugging property set
+ on current shell session for the duration of either the module command or the
  module shell initialization script. Only applies to Bourne Shell (sh) and its
  derivatives.
 
@@ -1436,8 +1473,8 @@ ENVIRONMENT
  Location of a site-specific configuration script to source into
  :file:`modulecmd.tcl`. See also `Modulecmd startup`_ section.
 
- This environment variable is ignored if ``extra_siteconfig`` has been declared
- locked in ``locked_configs`` configuration option.
+ This environment variable is ignored if ``extra_siteconfig`` has been
+ declared locked in ``locked_configs`` configuration option.
 
  .. only:: html
 
@@ -1448,7 +1485,8 @@ ENVIRONMENT
  Inform Modules of the terminal background color to determine if the color set
  for dark background or the color set for light background should be used to
  color output in case no specific color set is defined with the
- :envvar:`MODULES_COLORS` variable. Accepted values are ``dark`` and ``light``.
+ :envvar:`MODULES_COLORS` variable. Accepted values are ``dark`` and
+ ``light``.
 
  .. only:: html
 
@@ -1489,16 +1527,17 @@ ENVIRONMENT
    module evaluations triggered by loading or unloading modules, aborted
    evaluation issues or a report of each module evaluation occurring during a
    :subcmd:`restore` or :subcmd:`source` sub-commands.
- * ``verbose``: add additional informational messages, like a systematic report of
-   the loading or unloading module evaluations.
+ * ``verbose``: add additional informational messages, like a systematic
+   report of the loading or unloading module evaluations.
  * ``debug``: print debugging messages about module command execution.
 
  Module command verbosity is defined in the following order of preference:
- :option:`--silent`, :option:`--verbose` and :option:`--debug` command line switches, then
- :envvar:`MODULES_VERBOSITY` environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_VERBOSITY`
- overrides default configuration and :option:`--silent`/:option:`--verbose`/:option:`--debug`
- command line switches overrides every other ways to set verbosity level.
+ :option:`--silent`, :option:`--verbose` and :option:`--debug` command line
+ switches, then :envvar:`MODULES_VERBOSITY` environment variable, then the
+ default set in :file:`modulecmd.tcl` script configuration. Which means
+ :envvar:`MODULES_VERBOSITY` overrides default configuration and
+ :option:`--silent`/:option:`--verbose`/:option:`--debug` command line
+ switches overrides every other ways to set verbosity level.
 
  .. only:: html
 
@@ -1512,9 +1551,9 @@ ENVIRONMENT
  workaround is enabled, an alternative *module* alias is defined which fixes
  the history mechanism issue. However the alternative definition of the
  *module* alias weakens shell evaluation of the code produced by modulefiles.
- Characters with a special meaning for Tcsh shell (like ``{`` and ``}``) may not be
- used anymore in shell alias definition otherwise the evaluation of the code
- produced by modulefiles will return a syntax error.
+ Characters with a special meaning for Tcsh shell (like ``{`` and ``}``) may
+ not be used anymore in shell alias definition otherwise the evaluation of the
+ code produced by modulefiles will return a syntax error.
 
  .. only:: html
 
@@ -1526,8 +1565,8 @@ ENVIRONMENT
 
 .. envvar:: <VAR>_modquar
 
- Value of environment variable :envvar:`<VAR>` passed to :file:`modulecmd.tcl` in order
- to restore :envvar:`<VAR>` to this value once started.
+ Value of environment variable :envvar:`<VAR>` passed to :file:`modulecmd.tcl`
+ in order to restore :envvar:`<VAR>` to this value once started.
 
  .. only:: html
 
@@ -1555,9 +1594,9 @@ FILES
 
 |file etcdir_siteconfig|
 
- The site-specific configuration script of :file:`modulecmd.tcl`. An additional
- configuration script could be defined using the :envvar:`MODULES_SITECONFIG`
- environment variable.
+ The site-specific configuration script of :file:`modulecmd.tcl`. An
+ additional configuration script could be defined using the
+ :envvar:`MODULES_SITECONFIG` environment variable.
 
 |file etcdir_rc|
 
@@ -1575,8 +1614,8 @@ FILES
 |file modulefilesdir|
 
  The directory for system-wide *modulefiles*. The location of the directory
- can be changed using the :envvar:`MODULEPATH` environment variable as described
- above.
+ can be changed using the :envvar:`MODULEPATH` environment variable as
+ described above.
 
 |file libexecdir_modulecmd|
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -44,12 +44,12 @@ creates the :command:`module` command as either an alias or function and creates
 Modules environment variables.
 
 The :command:`module` alias or function executes the :file:`modulecmd.tcl` program
-located in |emph libexecdir| and has the shell evaluate the command's
+located in |file libexecdir| and has the shell evaluate the command's
 output. The first argument to :file:`modulecmd.tcl` specifies the type of shell.
 
-The initialization scripts are kept in |emph initdir|\ */<shell>* where
+The initialization scripts are kept in |file initdir_shell| where
 *<shell>* is the name of the sourcing shell. For example, a C Shell user
-sources the |emph initdir|\ */csh* script. The sh, csh, tcsh, bash, ksh,
+sources the |file initdir_csh| script. The sh, csh, tcsh, bash, ksh,
 zsh and fish shells are supported by :file:`modulecmd.tcl`. In addition,
 python, perl, ruby, tcl, cmake, r and lisp "shells" are supported which
 writes the environment changes to stdout as python, perl, ruby, tcl, lisp,
@@ -104,10 +104,10 @@ Modulecmd startup
 
 Upon invocation :file:`modulecmd.tcl` sources a site-specific configuration
 script if it exists. The location for this script is
-|emph etcdir|\ */siteconfig.tcl*. An additional siteconfig script may be
+|file etcdir_siteconfig|. An additional siteconfig script may be
 specified with the :envvar:`MODULES_SITECONFIG` environment variable, if allowed by
 :file:`modulecmd.tcl` configuration, and will be loaded if it exists after
-|emph etcdir|\ */siteconfig.tcl*. Siteconfig is a Tcl script that enables to
+|file etcdir_siteconfig|. Siteconfig is a Tcl script that enables to
 supersede any global variable or procedure definition of :file:`modulecmd.tcl`.
 
 Afterward, :file:`modulecmd.tcl` sources rc files which contain global,
@@ -117,7 +117,7 @@ user and *modulefile* specific setups. These files are interpreted as
 Upon invocation of :file:`modulecmd.tcl` module run-command files are sourced
 in the following order:
 
-1. Global RC file as specified by :envvar:`MODULERCFILE` variable or |emph etcdir|\ */rc*.
+1. Global RC file as specified by :envvar:`MODULERCFILE` variable or |file etcdir_rc|.
    If :envvar:`MODULERCFILE` points to a directory, the :file:`modulerc` file in this
    directory is used as global RC file.
 
@@ -896,7 +896,7 @@ ENVIRONMENT
 
  The path that the :command:`module` command searches when looking for
  *modulefiles*. Typically, it is set to the master *modulefiles* directory,
- |emph prefix|\ */modulefiles*, by the initialization script. :envvar:`MODULEPATH`
+ |file modulefilesdir|, by the initialization script. :envvar:`MODULEPATH`
  can be set using **module use** or by the module initialization script
  to search group or personal *modulefile* directories before or after the
  master *modulefile* directory.
@@ -1350,17 +1350,17 @@ ENVIRONMENT
 FILES
 -----
 
-|bold prefix|
+|file prefix|
 
  The :envvar:`MODULESHOME` directory.
 
-|bold etcdir|\ **/siteconfig.tcl**
+|file etcdir_siteconfig|
 
  The site-specific configuration script of :file:`modulecmd.tcl`. An additional
  configuration script could be defined using the :envvar:`MODULES_SITECONFIG`
  environment variable.
 
-|bold etcdir|\ **/rc**
+|file etcdir_rc|
 
  The system-wide modules rc file. The location of this file can be changed
  using the :envvar:`MODULERCFILE` environment variable as described above.
@@ -1373,18 +1373,18 @@ FILES
 
  The user specific collection directory.
 
-|bold modulefilesdir|
+|file modulefilesdir|
 
  The directory for system-wide *modulefiles*. The location of the directory
  can be changed using the :envvar:`MODULEPATH` environment variable as described
  above.
 
-|bold libexecdir|\ **/modulecmd.tcl**
+|file libexecdir_modulecmd|
 
  The *modulefile* interpreter that gets executed upon each invocation
  of :command:`module`.
 
-|bold initdir|\ **/<shell>**
+|file initdir_shell|
 
  The Modules package initialization file sourced into the user's environment.
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -429,6 +429,10 @@ Module Sub-Commands
  searched in the same manner than for the :subcmd:`avail` sub-command. Only the
  symbolic version-names and aliases found in the search are displayed.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: use [-a|--append] directory...
 
  Prepend one or more *directories* to the :envvar:`MODULEPATH` environment
@@ -464,6 +468,10 @@ Module Sub-Commands
  *modulefiles* have unsatisfied constraint corresponding to the :mfcmd:`prereq`
  and :mfcmd:`conflict` they declare.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: purge
 
  Unload all loaded *modulefiles*.
@@ -474,12 +482,22 @@ Module Sub-Commands
  confirmation is requested if command-line switch :option:`-f` (or :option:`--force`) is not
  passed. Typed confirmation should equal to ``yes`` or ``y`` in order to proceed.
 
+ .. only:: html
+
+    .. versionadded:: 4.3
+       :subcmd:`clear` support was dropped on version `4.0` but reintroduced
+       starting version `4.3`.
+
 .. subcmd:: source scriptfile...
 
  Execute *scriptfile* into the shell environment. *scriptfile* must be written
  with *modulefile* syntax and specified with a fully qualified path. Once
  executed *scriptfile* is not marked loaded in shell environment which differ
  from :subcmd:`load` sub-command.
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 .. subcmd:: whatis [modulefile...]
 
@@ -507,6 +525,12 @@ Module Sub-Commands
  a case insensitive manner will be displayed. *string* may contain wildcard
  characters.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+       Prior version `4.0` :mfcmd:`module-whatis` information search was
+       performed with :subcmd:`apropos` or :subcmd:`keyword` sub-commands.
+
 .. subcmd:: test modulefile...
 
  Execute and display results of the Module-specific tests for the
@@ -515,6 +539,10 @@ Module Sub-Commands
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 .. subcmd:: save [collection]
 
@@ -539,6 +567,10 @@ Module Sub-Commands
  *modulefiles* have unsatisfied constraint corresponding to the :mfcmd:`prereq`
  and :mfcmd:`conflict` they declare.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: restore [collection]
 
  Restore the environment state as defined in *collection*. If *collection*
@@ -562,12 +594,20 @@ Module Sub-Commands
  *collection* by its bare name: loading this module when restoring the
  collection will fail if the configuration option ``implicit_default`` is disabled.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: saverm [collection]
 
  Delete the *collection* file under the user's collection directory. If
  *collection* name is not specified, then it is assumed to be the *default*
  collection. If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to
  the value of this variable will be appended to the *collection* file name.
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 .. subcmd:: saveshow [collection]
 
@@ -578,11 +618,19 @@ Module Sub-Commands
  is set, a suffix equivalent to the value of this variable will be appended
  to the *collection* file name.
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: savelist [-t|-l]
 
  List collections that are currently saved under the user's collection
  directory. If :envvar:`MODULES_COLLECTION_TARGET` is set, only collections
  matching the target suffix will be displayed.
+
+ .. only:: html
+
+    .. versionadded:: 4.0
 
 .. subcmd:: initadd modulefile...
 
@@ -648,6 +696,10 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: paths modulefile
 
  Print path of available *modulefiles* matching argument.
@@ -656,11 +708,19 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
+ .. only:: html
+
+    .. versionadded:: 4.0
+
 .. subcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Append *value* to environment *variable*. The *variable* is a colon, or
  *delimiter*, separated list. See :mfcmd:`append-path` in the :ref:`modulefile(4)`
  man page for further explanation.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. subcmd:: prepend-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
@@ -668,11 +728,19 @@ Module Sub-Commands
  *delimiter*, separated list. See :mfcmd:`prepend-path` in the :ref:`modulefile(4)`
  man page for further explanation.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. subcmd:: remove-path [-d C|--delim C|--delim=C] [--index] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in environment
  *variable*. See :mfcmd:`remove-path` in the :ref:`modulefile(4)` man page for
  further explanation.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. subcmd:: is-loaded [modulefile...]
 
@@ -685,6 +753,10 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. subcmd:: is-saved [collection...]
 
  Returns a true value if any of the listed *collections* exists or if any
@@ -692,12 +764,20 @@ Module Sub-Commands
  otherwise. See :mfcmd:`is-saved` in the :ref:`modulefile(4)` man page for further
  explanation.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. subcmd:: is-used [directory...]
 
  Returns a true value if any of the listed *directories* has been enabled in
  :envvar:`MODULEPATH` or if any *directory* is enabled in case no argument is
  provided. Returns a false value otherwise. See :mfcmd:`is-used` in the
  :ref:`modulefile(4)` man page for further explanation.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. subcmd:: is-avail modulefile...
 
@@ -709,12 +789,20 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. subcmd:: info-loaded modulefile
 
  Returns the names of currently loaded modules matching passed *modulefile*.
  Returns an empty string if passed *modulefile* does not match any loaded
  modules. See :mfcmd:`module-info loaded<module-info>` in the :ref:`modulefile(4)` man page for
  further explanation.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. subcmd:: config [--dump-state|name [value]|--reset name]
 
@@ -790,6 +878,10 @@ The options ``avail_report_dir_sym``, ``avail_report_mfile_sym``, ``ignored_dirs
 ``locked_configs``, ``siteconfig`` and ``tcl_ext_lib`` cannot be altered. Moreover
 all options referred in ``locked_configs`` value are locked, thus they cannot be
 altered.
+
+ .. only:: html
+
+    .. versionadded:: 4.3
 
 
 Modulefiles

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -43,20 +43,20 @@ shell-specific initialization script is sourced into the shell. The script
 creates the **module** command as either an alias or function and creates
 Modules environment variables.
 
-The **module** alias or function executes the **modulecmd.tcl** program
+The **module** alias or function executes the :file:`modulecmd.tcl` program
 located in |emph libexecdir| and has the shell evaluate the command's
-output. The first argument to **modulecmd.tcl** specifies the type of shell.
+output. The first argument to :file:`modulecmd.tcl` specifies the type of shell.
 
 The initialization scripts are kept in |emph initdir|\ */<shell>* where
 *<shell>* is the name of the sourcing shell. For example, a C Shell user
 sources the |emph initdir|\ */csh* script. The sh, csh, tcsh, bash, ksh,
-zsh and fish shells are supported by **modulecmd.tcl**. In addition,
+zsh and fish shells are supported by :file:`modulecmd.tcl`. In addition,
 python, perl, ruby, tcl, cmake, r and lisp "shells" are supported which
 writes the environment changes to stdout as python, perl, ruby, tcl, lisp,
 r or cmake code.
 
 Initialization may also be performed by calling the **autoinit** sub-command
-of the **modulecmd.tcl** program. Evaluation into the shell of the result
+of the :file:`modulecmd.tcl` program. Evaluation into the shell of the result
 of this command defines the **module** alias or function.
 
 
@@ -102,28 +102,28 @@ Bourne Shell (sh) (and derivatives) with **autoinit** sub-command:
 Modulecmd startup
 ^^^^^^^^^^^^^^^^^
 
-Upon invocation **modulecmd.tcl** sources a site-specific configuration
+Upon invocation :file:`modulecmd.tcl` sources a site-specific configuration
 script if it exists. The location for this script is
 |emph etcdir|\ */siteconfig.tcl*. An additional siteconfig script may be
 specified with the *$MODULES_SITECONFIG* environment variable, if allowed by
-**modulecmd.tcl** configuration, and will be loaded if it exists after
+:file:`modulecmd.tcl` configuration, and will be loaded if it exists after
 |emph etcdir|\ */siteconfig.tcl*. Siteconfig is a Tcl script that enables to
-supersede any global variable or procedure definition of **modulecmd.tcl**.
+supersede any global variable or procedure definition of :file:`modulecmd.tcl`.
 
-Afterward, **modulecmd.tcl** sources rc files which contain global,
+Afterward, :file:`modulecmd.tcl` sources rc files which contain global,
 user and *modulefile* specific setups. These files are interpreted as
 *modulefiles*. See :ref:`modulefile(4)` for detailed information.
 
-Upon invocation of **modulecmd.tcl** module run-command files are sourced
+Upon invocation of :file:`modulecmd.tcl` module run-command files are sourced
 in the following order:
 
 1. Global RC file as specified by *$MODULERCFILE* or |emph etcdir|\ */rc*.
-   If *$MODULERCFILE* points to a directory, the *modulerc* file in this
+   If *$MODULERCFILE* points to a directory, the :file:`modulerc` file in this
    directory is used as global RC file.
 
-2. User specific module RC file *$HOME/.modulerc*
+2. User specific module RC file :file:`$HOME/.modulerc`
 
-3. All *.modulerc* and *.version* files found during modulefile seeking.
+3. All :file:`.modulerc` and :file:`.version` files found during modulefile seeking.
 
 
 Command line switches
@@ -491,7 +491,7 @@ Module Sub-Commands
 
  Record the currently set **MODULEPATH** directory list and the currently
  loaded *modulefiles* in a *collection* file under the user's collection
- directory *$HOME/.module*. If *collection* name is not specified, then
+ directory :file:`$HOME/.module`. If *collection* name is not specified, then
  it is assumed to be the *default* collection. If *collection* is a fully
  qualified path, it is saved at this location rather than under the user's
  collection directory.
@@ -572,27 +572,27 @@ Module Sub-Commands
 
  C Shell
 
-  *.modules*, *.cshrc*, *.csh_variables* and *.login*
+  :file:`.modules`, :file:`.cshrc`, :file:`.csh_variables` and :file:`.login`
 
  TENEX C Shell
 
-  *.modules*, *.tcshrc*, *.cshrc*, *.csh_variables* and *.login*
+  :file:`.modules`, :file:`.tcshrc`, :file:`.cshrc`, :file:`.csh_variables` and :file:`.login`
 
  Bourne and Korn Shells
 
-  *.modules*, *.profile*
+  :file:`.modules`, :file:`.profile`
 
  GNU Bourne Again Shell
 
-  *.modules*, *.bash_profile*, *.bash_login*, *.profile* and *.bashrc*
+  :file:`.modules`, :file:`.bash_profile`, :file:`.bash_login`, :file:`.profile` and :file:`.bashrc`
 
  Z Shell
 
-  *.modules*, *.zshrc*, *.zshenv* and *.zlogin*
+  :file:`.modules`, :file:`.zshrc`, :file:`.zshenv` and :file:`.zlogin`
 
  Friendly Interactive Shell
 
-  *.modules*, *.config/fish/config.fish*
+  :file:`.modules`, :file:`.config/fish/config.fish`
 
  If a **module load** line is found in any of these files, the *modulefiles*
  are appended to any existing list of *modulefiles*. The **module load**
@@ -731,7 +731,7 @@ Module Sub-Commands
 
 **config** [--dump-state|name [value]|--reset name]
 
- Gets or sets **modulecmd.tcl** options. Reports the currently set value of
+ Gets or sets :file:`modulecmd.tcl` options. Reports the currently set value of
  passed option *name* or all existing options if no *name* passed. If a *name*
  and a *value* are provided, the value of option *name* is set to *value*. If
  command-line switch *--reset* is passed in addition to a *name*, overridden
@@ -745,9 +745,9 @@ Module Sub-Commands
  If no value is currently set for an option *name*, the mention *<undef>* is
  reported.
 
- When command-line switch *--dump-state* is passed, current **modulecmd.tcl**
+ When command-line switch *--dump-state* is passed, current :file:`modulecmd.tcl`
  state and Modules-related environment variables are reported in addition to
- currently set **modulecmd.tcl** options.
+ currently set :file:`modulecmd.tcl` options.
 
  Existing option *names* are:
 
@@ -784,7 +784,7 @@ Module Sub-Commands
  * pager: text viewer to paginate message output (defines **MODULES_PAGER**)
  * rcfile: global run-command file location (defines **MODULERCFILE**)
  * run_quarantine: environment variables to indirectly pass to
-   **modulecmd.tcl** (defines **MODULES_RUN_QUARANTINE**)
+   :file:`modulecmd.tcl` (defines **MODULES_RUN_QUARANTINE**)
  * silent_shell_debug: disablement of shell debugging property for the module
    command (defines **MODULES_SILENT_SHELL_DEBUG**)
  * search_match: module search match style (defines **MODULES_SEARCH_MATCH**)
@@ -809,7 +809,7 @@ Modulefiles
 ^^^^^^^^^^^
 
 *modulefiles* are written in the Tool Command Language (Tcl) and are
-interpreted by **modulecmd.tcl**. *modulefiles* can use conditional
+interpreted by :file:`modulecmd.tcl`. *modulefiles* can use conditional
 statements. Thus the effect a *modulefile* will have on the environment
 may change depending upon the current state of the environment.
 
@@ -857,7 +857,7 @@ Collections
 ^^^^^^^^^^^
 
 Collections describe a sequence of **module use** then **module load**
-commands that are interpreted by **modulecmd.tcl** to set the user
+commands that are interpreted by :file:`modulecmd.tcl` to set the user
 environment as described by this sequence. When a collection is activated,
 with the **restore** sub-command, module paths and loaded modules are
 unused or unloaded if they are not part or if they are not ordered the
@@ -865,7 +865,7 @@ same way as in the collection.
 
 Collections are generated by the **save** sub-command that dumps the current
 user environment state in terms of module paths and loaded modules. By
-default collections are saved under the *$HOME/.module* directory.
+default collections are saved under the :file:`$HOME/.module` directory.
 
 Collections may be valid for a given target if they are suffixed. In this
 case these collections can only be restored if their suffix correspond to
@@ -926,7 +926,7 @@ ENVIRONMENT
 **MODULESHOME**
 
  The location of the master Modules package file directory containing module
- command initialization scripts, the executable program **modulecmd.tcl**,
+ command initialization scripts, the executable program :file:`modulecmd.tcl`,
  and a directory containing a collection of master *modulefiles*.
 
 .. _MODULES_ADVANCED_VERSION_SPEC:
@@ -939,7 +939,7 @@ ENVIRONMENT
 
  Advanced module version specifiers enablement is defined in the following
  order of preference: **MODULES_ADVANCED_VERSION_SPEC** environment variable
- then the default set in **modulecmd.tcl** script configuration. Which means
+ then the default set in :file:`modulecmd.tcl` script configuration. Which means
  **MODULES_ADVANCED_VERSION_SPEC** overrides default configuration.
 
 .. _MODULES_AUTO_HANDLING:
@@ -992,7 +992,7 @@ ENVIRONMENT
  Automated module handling mode enablement is defined in the following order
  of preference: **--auto**/**--no-auto** command line switches,
  then **MODULES_AUTO_HANDLING** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_AUTO_HANDLING**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_AUTO_HANDLING**
  overrides default configuration and **--auto**/**--no-auto** command line
  switches override every other ways to enable or disable this mode.
 
@@ -1012,7 +1012,7 @@ ENVIRONMENT
  **avail** sub-command in depth mode enablement is defined in the following
  order of preference: **--indepth**/**--no-indepth** command line switches,
  then **MODULES_AVAIL_INDEPTH** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_AVAIL_INDEPTH**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_AVAIL_INDEPTH**
  overrides default configuration and **--indepth**/**--no-indepth** command
  line switches override every other ways to enable or disable this mode.
 
@@ -1067,7 +1067,7 @@ ENVIRONMENT
  Colored output enablement is defined in the following order of preference:
  **--color** command line switch, then **MODULES_COLOR** environment variable,
  then **CLICOLOR** and **CLICOLOR_FORCE** environment variables, then the
- default set in **modulecmd.tcl** script configuration. Which means
+ default set in :file:`modulecmd.tcl` script configuration. Which means
  **MODULES_COLOR** overrides default configuration and the
  **CLICOLOR**/**CLICOLOR_FORCE** variables. **--color** command line switch
  overrides every other ways to enable or disable this mode.
@@ -1111,7 +1111,7 @@ ENVIRONMENT
 
  The color set is defined for Modules in the following order of preference:
  **MODULES_COLORS** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_COLORS**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_COLORS**
  overrides default configuration.
 
 .. _MODULES_EXTENDED_DEFAULT:
@@ -1130,7 +1130,7 @@ ENVIRONMENT
  modulefiles is returned if defined (see **MODULES_IMPLICIT_DEFAULT** section)
 
  This environment variable supersedes the value of the configuration option
- *extended_default* set in **modulecmd.tcl** script.
+ *extended_default* set in :file:`modulecmd.tcl` script.
 
 .. _MODULES_ICASE:
 
@@ -1148,7 +1148,7 @@ ENVIRONMENT
  Case sensitiveness behavior is defined in the following order of preference:
  **--icase** command line switch, which corresponds to the **always** mode,
  then **MODULES_ICASE** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_ICASE**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_ICASE**
  overrides default configuration and **--icase** command line switch overrides
  every other ways to set case sensitiveness behavior.
 
@@ -1178,7 +1178,7 @@ ENVIRONMENT
  implicit default version is defined.
 
  This environment variable supersedes the value of the configuration option
- *implicit_default* set in **modulecmd.tcl** script. This environment variable
+ *implicit_default* set in :file:`modulecmd.tcl` script. This environment variable
  is ignored if *implicit_default* has been declared locked in *locked_configs*
  configuration option.
 
@@ -1253,7 +1253,7 @@ ENVIRONMENT
 
  Paging command and options are defined for Modules in the following order of
  preference: **MODULES_PAGER** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_PAGER**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_PAGER**
  overrides default configuration.
 
  If **MODULES_PAGER** variable is set to an empty string or to the value
@@ -1263,7 +1263,7 @@ ENVIRONMENT
 
 **MODULES_RUNENV_<VAR>**
 
- Value to set to environment variable *<VAR>* for **modulecmd.tcl** run-time
+ Value to set to environment variable *<VAR>* for :file:`modulecmd.tcl` run-time
  execution if *<VAR>* is referred in **MODULES_RUN_QUARANTINE**.
 
 .. _MODULES_RUN_QUARANTINE:
@@ -1271,15 +1271,15 @@ ENVIRONMENT
 **MODULES_RUN_QUARANTINE**
 
  A space separated list of environment variable names that should be passed
- indirectly to **modulecmd.tcl** to protect its run-time environment from
+ indirectly to :file:`modulecmd.tcl` to protect its run-time environment from
  side-effect coming from their current definition.
 
  Each variable found in **MODULES_RUN_QUARANTINE** will have its value emptied
  or set to the value of the corresponding **MODULES_RUNENV_<VAR>** variable
- when defining **modulecmd.tcl** run-time environment.
+ when defining :file:`modulecmd.tcl` run-time environment.
 
  Original values of these environment variables set in quarantine are passed
- to **modulecmd.tcl** via **<VAR>_modquar** variables.
+ to :file:`modulecmd.tcl` via **<VAR>_modquar** variables.
 
 .. _MODULES_SEARCH_MATCH:
 
@@ -1294,7 +1294,7 @@ ENVIRONMENT
  Module search match style is defined in the following order of preference:
  **--starts-with** and **--contains** command line switches, then
  **MODULES_SEARCH_MATCH** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_SEARCH_MATCH**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_SEARCH_MATCH**
  overrides default configuration and **--starts-with**/**--contains** command
  line switches override every other ways to set search match style.
 
@@ -1322,7 +1322,7 @@ ENVIRONMENT
 **MODULES_SITECONFIG**
 
  Location of a site-specific configuration script to source into
- **modulecmd.tcl**. See also Modulecmd startup section.
+ :file:`modulecmd.tcl`. See also Modulecmd startup section.
 
  This environment variable is ignored if *extra_siteconfig* has been declared
  locked in *locked_configs* configuration option.
@@ -1376,7 +1376,7 @@ ENVIRONMENT
  Module command verbosity is defined in the following order of preference:
  **--silent**, **--verbose** and **--debug** command line switches, then
  **MODULES_VERBOSITY** environment variable, then the default set in
- **modulecmd.tcl** script configuration. Which means **MODULES_VERBOSITY**
+ :file:`modulecmd.tcl` script configuration. Which means **MODULES_VERBOSITY**
  overrides default configuration and **--silent**/**--verbose**/**--debug**
  command line switches overrides every other ways to set verbosity level.
 
@@ -1404,7 +1404,7 @@ ENVIRONMENT
 
 **<VAR>_modquar**
 
- Value of environment variable *<VAR>* passed to **modulecmd.tcl** in order
+ Value of environment variable *<VAR>* passed to :file:`modulecmd.tcl` in order
  to restore *<VAR>* to this value once started.
 
 .. _<VAR>_modshare:
@@ -1427,7 +1427,7 @@ FILES
 
 |bold etcdir|\ **/siteconfig.tcl**
 
- The site-specific configuration script of **modulecmd.tcl**. An additional
+ The site-specific configuration script of :file:`modulecmd.tcl`. An additional
  configuration script could be defined using the **MODULES_SITECONFIG**
  environment variable.
 
@@ -1436,11 +1436,11 @@ FILES
  The system-wide modules rc file. The location of this file can be changed
  using the **MODULERCFILE** environment variable as described above.
 
-**$HOME/.modulerc**
+:file:`$HOME/.modulerc`
 
  The user specific modules rc file.
 
-**$HOME/.module**
+:file:`$HOME/.module`
 
  The user specific collection directory.
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -170,7 +170,7 @@ switches are accepted:
 
 .. option:: --color=<WHEN>
 
- Colorize the output. *WHEN* defaults to *always* or can be *never* or *auto*.
+ Colorize the output. *WHEN* defaults to ``always`` or can be ``never`` or ``auto``.
  See also :envvar:`MODULES_COLOR` section.
 
 .. option:: --auto
@@ -206,7 +206,7 @@ switches are accepted:
 
  On :subcmd:`avail` sub-command, display only the default version of each module
  name. Default version is the explicitly set default version or also the
- implicit default version if the configuration option *implicit_default* is enabled
+ implicit default version if the configuration option ``implicit_default`` is enabled
  (see :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page for
  further details on implicit default version).
 
@@ -329,15 +329,15 @@ Module Sub-Commands
  result of this sub-command. Symbolic version-names are displayed next to
  the *modulefile* they are assigned to within parenthesis. Aliases are listed
  in the :envvar:`MODULEPATH` section where they have been defined. To distinguish
- aliases from *modulefiles* a **@** symbol is added within parenthesis
+ aliases from *modulefiles* a ``@`` symbol is added within parenthesis
  next to their name. Aliases defined through a global or user specific
  module RC file are listed under the **global/user modulerc** section.
 
  When colored output is enabled and a specific graphical rendition is defined
- for module *default* version, the **default** symbol is omitted and instead
+ for module *default* version, the ``default`` symbol is omitted and instead
  the defined graphical rendition is applied to the relative modulefile. When
  colored output is enabled and a specific graphical rendition is defined for
- module alias, the **@** symbol is omitted. The defined graphical rendition
+ module alias, the ``@`` symbol is omitted. The defined graphical rendition
  applies to the module alias name. See :envvar:`MODULES_COLOR` and
  :envvar:`MODULES_COLORS` sections for details on colored output.
 
@@ -395,7 +395,7 @@ Module Sub-Commands
 
  Force the Modules package to believe that no modules are currently loaded. A
  confirmation is requested if command-line switch :option:`-f` (or :option:`--force`) is not
- passed. Typed confirmation should equal to *yes* or *y* in order to proceed.
+ passed. Typed confirmation should equal to ``yes`` or ``y`` in order to proceed.
 
 .. subcmd:: source scriptfile...
 
@@ -444,18 +444,18 @@ Module Sub-Commands
  Record the currently set :envvar:`MODULEPATH` directory list and the currently
  loaded *modulefiles* in a *collection* file under the user's collection
  directory :file:`$HOME/.module`. If *collection* name is not specified, then
- it is assumed to be the *default* collection. If *collection* is a fully
+ it is assumed to be the ``default`` collection. If *collection* is a fully
  qualified path, it is saved at this location rather than under the user's
  collection directory.
 
  If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
  of this variable will be appended to the *collection* file name.
 
- By default, if loaded modulefile corresponds to the explicitly defined
+ By default, if a loaded modulefile corresponds to the explicitly defined
  default module version, the bare module name is recorded. If the configuration
- option *implicit_default* is enabled, the bare module name is also recorded
+ option ``implicit_default`` is enabled, the bare module name is also recorded
  for the implicit default module version. If
- :envvar:`MODULES_COLLECTION_PIN_VERSION` is set to **1**, module version is always
+ :envvar:`MODULES_COLLECTION_PIN_VERSION` is set to ``1``, module version is always
  recorded even if it is the default version.
 
  No *collection* is recorded and an error is returned if the loaded
@@ -483,7 +483,7 @@ Module Sub-Commands
 
  If a module, without a default version explicitly defined, is recorded in a
  *collection* by its bare name: loading this module when restoring the
- collection will fail if the configuration option *implicit_default* is disabled.
+ collection will fail if the configuration option ``implicit_default`` is disabled.
 
 .. subcmd:: saverm [collection]
 
@@ -645,14 +645,14 @@ Module Sub-Commands
  passed option *name* or all existing options if no *name* passed. If a *name*
  and a *value* are provided, the value of option *name* is set to *value*. If
  command-line switch ``--reset`` is passed in addition to a *name*, overridden
- overridden value for option *name* is cleared.
+ value for option *name* is cleared.
 
  When a reported option value differs from default value a mention is added
  to indicate whether the overridden value is coming from a command-line switch
- (*cmd-line*) or from an environment variable (*env-var*). When a reported
- option value is locked and cannot be altered a (*locked*) mention is added.
+ (``cmd-line``) or from an environment variable (``env-var``). When a reported
+ option value is locked and cannot be altered a (``locked``) mention is added.
 
- If no value is currently set for an option *name*, the mention *<undef>* is
+ If no value is currently set for an option *name*, the mention ``<undef>`` is
  reported.
 
  When command-line switch ``--dump-state`` is passed, current :file:`modulecmd.tcl`
@@ -661,57 +661,57 @@ Module Sub-Commands
 
  Existing option *names* are:
 
- * advanced_version_spec: advanced module version specification to finely
+ * ``advanced_version_spec``: advanced module version specification to finely
    select modulefiles (defines environment variable
    :envvar:`MODULES_ADVANCED_VERSION_SPEC` when set
- * auto_handling: automated module handling mode (defines
+ * ``auto_handling``: automated module handling mode (defines
    :envvar:`MODULES_AUTO_HANDLING`)
- * avail_indepth: :subcmd:`avail` sub-command in depth search mode (defines
+ * ``avail_indepth``: :subcmd:`avail` sub-command in depth search mode (defines
    :envvar:`MODULES_AVAIL_INDEPTH`)
- * avail_report_dir_sym: display symbolic versions targeting directories on
+ * ``avail_report_dir_sym``: display symbolic versions targeting directories on
    :subcmd:`avail` sub-command
- * avail_report_mfile_sym: display symbolic versions targeting modulefiles on
+ * ``avail_report_mfile_sym``: display symbolic versions targeting modulefiles on
    :subcmd:`avail` sub-command
- * collection_pin_version: register exact modulefile version in collection
+ * ``collection_pin_version``: register exact modulefile version in collection
    (defines :envvar:`MODULES_COLLECTION_PIN_VERSION`)
- * collection_target: collection target which is valid for current system
+ * ``collection_target``: collection target which is valid for current system
    (defines :envvar:`MODULES_COLLECTION_TARGET`)
- * color: colored output mode (defines :envvar:`MODULES_COLOR`)
- * colors: chosen colors to highlight output items (defines
+ * ``color``: colored output mode (defines :envvar:`MODULES_COLOR`)
+ * ``colors``: chosen colors to highlight output items (defines
    :envvar:`MODULES_COLORS`)
- * contact: modulefile contact address (defines :envvar:`MODULECONTACT`)
- * extended_default: allow partial module version specification (defines
+ * ``contact``: modulefile contact address (defines :envvar:`MODULECONTACT`)
+ * ``extended_default``: allow partial module version specification (defines
    :envvar:`MODULES_EXTENDED_DEFAULT`)
- * extra_siteconfig: additional site-specific configuration script location
+ * ``extra_siteconfig``: additional site-specific configuration script location
    (defines :envvar:`MODULES_SITECONFIG`)
- * home: location of Modules package master directory (defines
+ * ``home``: location of Modules package master directory (defines
    :envvar:`MODULESHOME`)
- * icase: enable case insensitive match (defines :envvar:`MODULES_ICASE`)
- * ignored_dirs: directories ignored when looking for modulefiles
- * implicit_default: set an implicit default version for modules (defines
+ * ``icase``: enable case insensitive match (defines :envvar:`MODULES_ICASE`)
+ * ``ignored_dirs``: directories ignored when looking for modulefiles
+ * ``implicit_default``: set an implicit default version for modules (defines
    :envvar:`MODULES_IMPLICIT_DEFAULT`)
- * locked_configs: configuration options that cannot be superseded
- * pager: text viewer to paginate message output (defines :envvar:`MODULES_PAGER`)
- * rcfile: global run-command file location (defines :envvar:`MODULERCFILE`)
- * run_quarantine: environment variables to indirectly pass to
+ * ``locked_configs``: configuration options that cannot be superseded
+ * ``pager``: text viewer to paginate message output (defines :envvar:`MODULES_PAGER`)
+ * ``rcfile``: global run-command file location (defines :envvar:`MODULERCFILE`)
+ * ``run_quarantine``: environment variables to indirectly pass to
    :file:`modulecmd.tcl` (defines :envvar:`MODULES_RUN_QUARANTINE`)
- * silent_shell_debug: disablement of shell debugging property for the module
+ * ``silent_shell_debug``: disablement of shell debugging property for the module
    command (defines :envvar:`MODULES_SILENT_SHELL_DEBUG`)
- * search_match: module search match style (defines :envvar:`MODULES_SEARCH_MATCH`)
- * set_shell_startup: ensure module command definition by setting shell
+ * ``search_match``: module search match style (defines :envvar:`MODULES_SEARCH_MATCH`)
+ * ``set_shell_startup``: ensure module command definition by setting shell
    startup file (defines :envvar:`MODULES_SET_SHELL_STARTUP`)
- * siteconfig: primary site-specific configuration script location
- * tcl_ext_lib: Modules Tcl extension library location
- * term_background: terminal background color kind (defines
+ * ``siteconfig``: primary site-specific configuration script location
+ * ``tcl_ext_lib``: Modules Tcl extension library location
+ * ``term_background``: terminal background color kind (defines
    :envvar:`MODULES_TERM_BACKGROUND`)
- * unload_match_order: unload firstly loaded or lastly loaded module matching
+ * ``unload_match_order``: unload firstly loaded or lastly loaded module matching
    request (defines :envvar:`MODULES_UNLOAD_MATCH_ORDER`)
- * verbosity: module command verbosity level (defines :envvar:`MODULES_VERBOSITY`)
- * wa_277: workaround for Tcsh history issue (defines :envvar:`MODULES_WA_277`)
+ * ``verbosity``: module command verbosity level (defines :envvar:`MODULES_VERBOSITY`)
+ * ``wa_277``: workaround for Tcsh history issue (defines :envvar:`MODULES_WA_277`)
 
-The options *avail_report_dir_sym*, *avail_report_mfile_sym*, *ignored_dirs*,
-*locked_configs*, *siteconfig* and *tcl_ext_lib* cannot be altered. Moreover
-all options referred in *locked_configs* value are locked thus they cannot be
+The options ``avail_report_dir_sym``, ``avail_report_mfile_sym``, ``ignored_dirs``,
+``locked_configs``, ``siteconfig`` and ``tcl_ext_lib`` cannot be altered. Moreover
+all options referred in ``locked_configs`` value are locked, thus they cannot be
 altered.
 
 
@@ -786,8 +786,8 @@ the current value of the :envvar:`MODULES_COLLECTION_TARGET` environment variabl
 EXIT STATUS
 -----------
 
-The :command:`module` command exits with **0** if its execution succeed. Otherwise
-**1** is returned.
+The :command:`module` command exits with ``0`` if its execution succeed. Otherwise
+``1`` is returned.
 
 
 ENVIRONMENT
@@ -830,8 +830,8 @@ ENVIRONMENT
 
 .. envvar:: MODULES_ADVANCED_VERSION_SPEC
 
- If set to **1**, enable advanced module version specifiers (see `Advanced
- module version specifiers`_ section). If set to **0**, disable advanced
+ If set to ``1``, enable advanced module version specifiers (see `Advanced
+ module version specifiers`_ section). If set to ``0``, disable advanced
  module version specifiers.
 
  Advanced module version specifiers enablement is defined in the following
@@ -841,7 +841,7 @@ ENVIRONMENT
 
 .. envvar:: MODULES_AUTO_HANDLING
 
- If set to **1**, enable automated module handling mode. If set to **0**
+ If set to ``1``, enable automated module handling mode. If set to ``0``
  disable automated module handling mode. Other values are ignored.
 
  Automated module handling mode consists in additional actions triggered when
@@ -893,8 +893,8 @@ ENVIRONMENT
 
 .. envvar:: MODULES_AVAIL_INDEPTH
 
- If set to **1**, enable in depth search results for :subcmd:`avail` sub-command. If
- set to **0** disable :subcmd:`avail` sub-command in depth mode. Other values are
+ If set to ``1``, enable in depth search results for :subcmd:`avail` sub-command. If
+ set to ``0`` disable :subcmd:`avail` sub-command in depth mode. Other values are
  ignored.
 
  When in depth mode is enabled, modulefiles and directories contained in
@@ -915,10 +915,10 @@ ENVIRONMENT
 
 .. envvar:: MODULES_COLLECTION_PIN_VERSION
 
- If set to **1**, register exact version number of modulefiles when saving a
+ If set to ``1``, register exact version number of modulefiles when saving a
  collection. Otherwise modulefile version number is omitted if it corresponds
  to the explicitly set default version and also to the implicit default when
- the configuration option *implicit_default* is enabled.
+ the configuration option ``implicit_default`` is enabled.
 
 .. envvar:: MODULES_COLLECTION_TARGET
 
@@ -943,10 +943,10 @@ ENVIRONMENT
 
 .. envvar:: MODULES_COLOR
 
- Defines if output should be colored or not. Accepted values are *never*,
- *auto* and *always*.
+ Defines if output should be colored or not. Accepted values are ``never``,
+ ``auto`` and ``always``.
 
- When color mode is set to *auto*, output is colored only if the standard
+ When color mode is set to ``auto``, output is colored only if the standard
  error output channel is attached to a terminal.
 
  Colored output enablement is defined in the following order of preference:
@@ -958,10 +958,10 @@ ENVIRONMENT
  overrides every other ways to enable or disable this mode.
 
  :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables are also honored to
- define color mode. The *never* mode is set if :envvar:`CLICOLOR` equals to **0**.
- If :envvar:`CLICOLOR` is set to another value, it corresponds to the *auto* mode.
- The *always* mode is set if :envvar:`CLICOLOR_FORCE` is set to a value different
- than **0**. Color mode set with these two variables is superseded by mode set
+ define color mode. The ``never`` mode is set if :envvar:`CLICOLOR` equals to ``0``.
+ If :envvar:`CLICOLOR` is set to another value, it corresponds to the ``auto`` mode.
+ The ``always`` mode is set if :envvar:`CLICOLOR_FORCE` is set to a value different
+ than ``0``. Color mode set with these two variables is superseded by mode set
  with :envvar:`MODULES_COLOR` environment variable.
 
 .. envvar:: MODULES_COLORS
@@ -972,19 +972,19 @@ ENVIRONMENT
  :envvar:`LS_COLORS`.
 
  Output items are designated by keys. Items able to be colorized are:
- highlighted element (*hi*), debug information (*db*), tag separator (*se*);
- Error (*er*), warning (*wa*), module error (*me*) and info (*in*) message
- prefixes; Modulepath (*mp*), directory (*di*), module alias (*al*), module
- symbolic version (*sy*), module *default* version (*de*) and modulefile
- command (*cm*).
+ highlighted element (``hi``), debug information (``db``), tag separator (``se``);
+ Error (``er``), warning (``wa``), module error (``me``) and info (``in``) message
+ prefixes; Modulepath (``mp``), directory (``di``), module alias (``al``), module
+ symbolic version (``sy``), module ``default`` version (``de``) and modulefile
+ command (``cm``).
 
  See the Select Graphic Rendition (SGR) section in the documentation of the
  text terminal that is used for permitted values and their meaning as
  character attributes. These substring values are integers in decimal
  representation and can be concatenated with semicolons. Modules takes care of
- assembling the result into a complete SGR sequence (**\33[...m**). Common
- values to concatenate include 1 for bold, 4 for underline, 30 to 37 for
- foreground colors and 90 to 97 for 16-color mode foreground colors. See also
+ assembling the result into a complete SGR sequence (``\33[...m``). Common
+ values to concatenate include ``1`` for bold, ``4`` for underline, ``30`` to ``37`` for
+ foreground colors and ``90`` to ``97`` for 16-color mode foreground colors. See also
  https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
  for a complete SGR code reference.
 
@@ -999,7 +999,7 @@ ENVIRONMENT
 
 .. envvar:: MODULES_EXTENDED_DEFAULT
 
- If set to **1**, a specified module version is matched against starting
+ If set to ``1``, a specified module version is matched against starting
  portion of existing module versions, where portion is a substring separated
  from the rest of the version string by a ``.`` character. For example
  specified modules ``mod/1`` and ``mod/1.2`` will match existing  modulefile
@@ -1011,21 +1011,21 @@ ENVIRONMENT
  modulefiles is returned if defined (see :envvar:`MODULES_IMPLICIT_DEFAULT` section)
 
  This environment variable supersedes the value of the configuration option
- *extended_default* set in :file:`modulecmd.tcl` script.
+ ``extended_default`` set in :file:`modulecmd.tcl` script.
 
 .. envvar:: MODULES_ICASE
 
  When module specification are passed as argument to module sub-commands or
  modulefile Tcl commands, defines the case sensitiveness to apply to match
- them. When :envvar:`MODULES_ICASE` is set to **never**, a case sensitive match is
- applied in any cases. When set to **search**, a case insensitive match is
+ them. When :envvar:`MODULES_ICASE` is set to ``never``, a case sensitive match is
+ applied in any cases. When set to ``search``, a case insensitive match is
  applied to the :subcmd:`avail`, :subcmd:`whatis` and :subcmd:`paths` sub-commands. When set to
- **always**, a case insensitive match is also applied to the other module
+ ``always``, a case insensitive match is also applied to the other module
  sub-commands and modulefile Tcl commands for the module specification they
  receive as argument.
 
  Case sensitiveness behavior is defined in the following order of preference:
- :option:`--icase` command line switch, which corresponds to the **always** mode,
+ :option:`--icase` command line switch, which corresponds to the ``always`` mode,
  then :envvar:`MODULES_ICASE` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_ICASE`
  overrides default configuration and :option:`--icase` command line switch overrides
@@ -1033,7 +1033,7 @@ ENVIRONMENT
 
 .. envvar:: MODULES_IMPLICIT_DEFAULT
 
- Defines (if set to **1**) or not (if set to **0**) an implicit default
+ Defines (if set to ``1``) or not (if set to ``0``) an implicit default
  version for modules without a default version explicitly defined (see
  :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page).
 
@@ -1055,8 +1055,8 @@ ENVIRONMENT
  implicit default version is defined.
 
  This environment variable supersedes the value of the configuration option
- *implicit_default* set in :file:`modulecmd.tcl` script. This environment variable
- is ignored if *implicit_default* has been declared locked in *locked_configs*
+ ``implicit_default`` set in :file:`modulecmd.tcl` script. This environment variable
+ is ignored if ``implicit_default`` has been declared locked in ``locked_configs``
  configuration option.
 
 .. envvar:: MODULES_LMALTNAME
@@ -1102,7 +1102,7 @@ ENVIRONMENT
  A colon separated list of the :mfcmd:`prereq` statements defined by all loaded
  *modulefiles*. Each element in this list starts by the name of the loaded
  *modulefile* declaring the pre-requirement followed by the name of all
- modulefiles it declares a prereq with. These loaded modulefiles and
+ modulefiles it declares a :mfcmd:`prereq` with. These loaded modulefiles and
  pre-required modulefile names are separated by the ampersand character. When
  a :mfcmd:`prereq` statement is composed of multiple modulefiles, these modulefile
  names are separated by the pipe character.
@@ -1124,7 +1124,7 @@ ENVIRONMENT
  overrides default configuration.
 
  If :envvar:`MODULES_PAGER` variable is set to an empty string or to the value
- *cat*, pager will not be launched.
+ ``cat``, pager will not be launched.
 
 .. envvar:: MODULES_RUNENV_<VAR>
 
@@ -1147,9 +1147,9 @@ ENVIRONMENT
 .. envvar:: MODULES_SEARCH_MATCH
 
  When searching for modules with :subcmd:`avail` sub-command, defines the way query
- string should match against available module names. With **starts_with**
+ string should match against available module names. With ``starts_with``
  value, returned modules are those whose name begins by search query string.
- When set to **contains**, any modules whose fully qualified name contains
+ When set to ``contains``, any modules whose fully qualified name contains
  search query string are returned.
 
  Module search match style is defined in the following order of preference:
@@ -1161,15 +1161,15 @@ ENVIRONMENT
 
 .. envvar:: MODULES_SET_SHELL_STARTUP
 
- If set to **1**, defines when :command:`module` command initializes the shell
+ If set to ``1``, defines when :command:`module` command initializes the shell
  startup file to ensure that the :command:`module` command is still defined in
  sub-shells. Setting shell startup file means defining the :envvar:`ENV` and
  :envvar:`BASH_ENV` environment variable to the Modules bourne shell initialization
- script. If set to **0**, shell startup file is not defined.
+ script. If set to ``0``, shell startup file is not defined.
 
 .. envvar:: MODULES_SILENT_SHELL_DEBUG
 
- If set to **1**, disable any *xtrace* or *verbose* debugging property set on
+ If set to ``1``, disable any ``xtrace`` or ``verbose`` debugging property set on
  current shell session for the duration of either the module command or the
  module shell initialization script. Only applies to Bourne Shell (sh) and its
  derivatives.
@@ -1179,25 +1179,25 @@ ENVIRONMENT
  Location of a site-specific configuration script to source into
  :file:`modulecmd.tcl`. See also `Modulecmd startup`_ section.
 
- This environment variable is ignored if *extra_siteconfig* has been declared
- locked in *locked_configs* configuration option.
+ This environment variable is ignored if ``extra_siteconfig`` has been declared
+ locked in ``locked_configs`` configuration option.
 
 .. envvar:: MODULES_TERM_BACKGROUND
 
  Inform Modules of the terminal background color to determine if the color set
  for dark background or the color set for light background should be used to
  color output in case no specific color set is defined with the
- :envvar:`MODULES_COLORS` variable. Accepted values are **dark** and **light**.
+ :envvar:`MODULES_COLORS` variable. Accepted values are ``dark`` and ``light``.
 
 .. envvar:: MODULES_UNLOAD_MATCH_ORDER
 
  When a module unload request matches multiple loaded modules, unload firstly
- loaded module or lastly loaded module. Accepted values are **returnfirst**
- and **returnlast**.
+ loaded module or lastly loaded module. Accepted values are ``returnfirst``
+ and ``returnlast``.
 
 .. envvar:: MODULES_USE_COMPAT_VERSION
 
- If set to **1** prior to Modules package initialization, enable
+ If set to ``1`` prior to Modules package initialization, enable
  Modules compatibility version (3.2 release branch) rather main version
  at initialization scripts running time. Modules package compatibility
  version should be installed along with main version for this environment
@@ -1208,17 +1208,17 @@ ENVIRONMENT
  Defines the verbosity level of the module command. Available verbosity levels
  from the least to the most verbose are:
 
- * silent: turn off error, warning and informational messages but does not
+ * ``silent``: turn off error, warning and informational messages but does not
    affect module command output result.
- * concise: enable error and warning messages but disable informational
+ * ``concise``: enable error and warning messages but disable informational
    messages.
- * normal: turn on informational messages, like a report of the additional
+ * ``normal``: turn on informational messages, like a report of the additional
    module evaluations triggered by loading or unloading modules, aborted
    evaluation issues or a report of each module evaluation occurring during a
    :subcmd:`restore` or :subcmd:`source` sub-commands.
- * verbose: add additional informational messages, like a systematic report of
+ * ``verbose``: add additional informational messages, like a systematic report of
    the loading or unloading module evaluations.
- * debug: print debugging messages about module command execution.
+ * ``debug``: print debugging messages about module command execution.
 
  Module command verbosity is defined in the following order of preference:
  :option:`--silent`, :option:`--verbose` and :option:`--debug` command line switches, then
@@ -1229,13 +1229,13 @@ ENVIRONMENT
 
 .. envvar:: MODULES_WA_277
 
- If set to **1** prior to Modules package initialization, enables workaround
+ If set to ``1`` prior to Modules package initialization, enables workaround
  for Tcsh history issue (see https://github.com/cea-hpc/modules/issues/277).
  This issue leads to erroneous history entries under Tcsh shell. When
  workaround is enabled, an alternative *module* alias is defined which fixes
  the history mechanism issue. However the alternative definition of the
  *module* alias weakens shell evaluation of the code produced by modulefiles.
- Characters with a special meaning for Tcsh shell (like *{* and *}*) may not be
+ Characters with a special meaning for Tcsh shell (like ``{`` and ``}``) may not be
  used anymore in shell alias definition otherwise the evaluation of the code
  produced by modulefiles will return a syntax error.
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -22,7 +22,7 @@ shell for an application. Once the Modules package is initialized, the
 environment can be modified on a per-module basis using the :command:`module`
 command which interprets *modulefiles*. Typically *modulefiles* instruct
 the :command:`module` command to alter or set shell environment variables such
-as **PATH**, **MANPATH**, etc. *Modulefiles* may be shared by many users
+as :envvar:`PATH`, :envvar:`MANPATH`, etc. *Modulefiles* may be shared by many users
 on a system and users may have their own set to supplement or replace the
 shared *modulefiles*.
 
@@ -105,7 +105,7 @@ Modulecmd startup
 Upon invocation :file:`modulecmd.tcl` sources a site-specific configuration
 script if it exists. The location for this script is
 |emph etcdir|\ */siteconfig.tcl*. An additional siteconfig script may be
-specified with the *$MODULES_SITECONFIG* environment variable, if allowed by
+specified with the :envvar:`MODULES_SITECONFIG` environment variable, if allowed by
 :file:`modulecmd.tcl` configuration, and will be loaded if it exists after
 |emph etcdir|\ */siteconfig.tcl*. Siteconfig is a Tcl script that enables to
 supersede any global variable or procedure definition of :file:`modulecmd.tcl`.
@@ -117,8 +117,8 @@ user and *modulefile* specific setups. These files are interpreted as
 Upon invocation of :file:`modulecmd.tcl` module run-command files are sourced
 in the following order:
 
-1. Global RC file as specified by *$MODULERCFILE* or |emph etcdir|\ */rc*.
-   If *$MODULERCFILE* points to a directory, the :file:`modulerc` file in this
+1. Global RC file as specified by :envvar:`MODULERCFILE` variable or |emph etcdir|\ */rc*.
+   If :envvar:`MODULERCFILE` points to a directory, the :file:`modulerc` file in this
    directory is used as global RC file.
 
 2. User specific module RC file :file:`$HOME/.modulerc`
@@ -161,8 +161,8 @@ switches are accepted:
 
 **--paginate**
 
- Pipe all message output into :command:`less` (or if set, *$MODULES_PAGER*) if error
- output stream is a terminal. See also **MODULES_PAGER** section.
+ Pipe all message output into :command:`less` (or if set, to the command referred in :envvar:`MODULES_PAGER` variable) if error
+ output stream is a terminal. See also :envvar:`MODULES_PAGER` section.
 
 **--no-pager**
 
@@ -171,17 +171,17 @@ switches are accepted:
 **--color**\[=\ *WHEN*\]
 
  Colorize the output. *WHEN* defaults to *always* or can be *never* or *auto*.
- See also **MODULES_COLOR** section.
+ See also :envvar:`MODULES_COLOR` section.
 
 **--auto**
 
  On **load**, **unload** and **switch** sub-commands, enable automated module
- handling mode. See also **MODULES_AUTO_HANDLING** section.
+ handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
 **--no-auto**
 
  On **load**, **unload** and **switch** sub-commands, disable automated module
- handling mode. See also **MODULES_AUTO_HANDLING** section.
+ handling mode. See also :envvar:`MODULES_AUTO_HANDLING` section.
 
 **--force**, **-f**
 
@@ -336,10 +336,10 @@ Module Sub-Commands
 
 **avail** [-d|-L] [-t|-l] [-S|-C] [--indepth|--no-indepth] [path...]
 
- List all available *modulefiles* in the current **MODULEPATH**. All
- directories in the **MODULEPATH** are recursively searched for files
+ List all available *modulefiles* in the current :envvar:`MODULEPATH`. All
+ directories in the :envvar:`MODULEPATH` are recursively searched for files
  containing the *modulefile* magic cookie. If an argument is given, then
- each directory in the **MODULEPATH** is searched for *modulefiles* whose
+ each directory in the :envvar:`MODULEPATH` is searched for *modulefiles* whose
  pathname, symbolic version-name or alias match the argument. Argument
  may contain wildcard characters. Multiple versions of an application can
  be supported by creating a subdirectory for the application containing
@@ -348,7 +348,7 @@ Module Sub-Commands
  Symbolic version-names and aliases found in the search are displayed in the
  result of this sub-command. Symbolic version-names are displayed next to
  the *modulefile* they are assigned to within parenthesis. Aliases are listed
- in the **MODULEPATH** section where they have been defined. To distinguish
+ in the :envvar:`MODULEPATH` section where they have been defined. To distinguish
  aliases from *modulefiles* a **@** symbol is added within parenthesis
  next to their name. Aliases defined through a global or user specific
  module RC file are listed under the **global/user modulerc** section.
@@ -358,8 +358,8 @@ Module Sub-Commands
  the defined graphical rendition is applied to the relative modulefile. When
  colored output is enabled and a specific graphical rendition is defined for
  module alias, the **@** symbol is omitted. The defined graphical rendition
- applies to the module alias name. See **MODULES_COLOR** and
- **MODULES_COLORS** sections for details on colored output.
+ applies to the module alias name. See :envvar:`MODULES_COLOR` and
+ :envvar:`MODULES_COLORS` sections for details on colored output.
 
  The parameter *path* may also refer to a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -370,7 +370,7 @@ Module Sub-Commands
 **aliases**
 
  List all available symbolic version-names and aliases in the current
- **MODULEPATH**.  All directories in the **MODULEPATH** are recursively
+ :envvar:`MODULEPATH`.  All directories in the :envvar:`MODULEPATH` are recursively
  searched in the same manner than for the **avail** sub-command. Only the
  symbolic version-names and aliases found in the search are displayed.
 
@@ -378,25 +378,25 @@ Module Sub-Commands
 
 **use** [-a|--append] directory...
 
- Prepend one or more *directories* to the **MODULEPATH** environment
+ Prepend one or more *directories* to the :envvar:`MODULEPATH` environment
  variable.  The *--append* flag will append the *directory* to
- **MODULEPATH**.
+ :envvar:`MODULEPATH`.
 
- Reference counter environment variable **MODULEPATH_modshare** is
+ Reference counter environment variable :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>` is
  also set to increase the number of times *directory* has been added to
- **MODULEPATH**.
+ :envvar:`MODULEPATH`.
 
 .. _unuse:
 
 **unuse** directory...
 
- Remove one or more *directories* from the **MODULEPATH** environment
+ Remove one or more *directories* from the :envvar:`MODULEPATH` environment
  variable if reference counter of these *directories* is equal to 1
  or unknown.
 
- Reference counter of *directory* in **MODULEPATH** denotes the number of
+ Reference counter of *directory* in :envvar:`MODULEPATH` denotes the number of
  times *directory* has been enabled. When attempting to remove *directory*
- from **MODULEPATH**, reference counter variable **MODULEPATH_modshare**
+ from :envvar:`MODULEPATH`, reference counter variable :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>`
  is checked and *directory* is removed only if its relative counter is
  equal to 1 or not defined. Otherwise *directory* is kept and reference
  counter is decreased by 1.
@@ -489,21 +489,21 @@ Module Sub-Commands
 
 **save** [collection]
 
- Record the currently set **MODULEPATH** directory list and the currently
+ Record the currently set :envvar:`MODULEPATH` directory list and the currently
  loaded *modulefiles* in a *collection* file under the user's collection
  directory :file:`$HOME/.module`. If *collection* name is not specified, then
  it is assumed to be the *default* collection. If *collection* is a fully
  qualified path, it is saved at this location rather than under the user's
  collection directory.
 
- If **MODULES_COLLECTION_TARGET** is set, a suffix equivalent to the value
+ If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
  of this variable will be appended to the *collection* file name.
 
  By default, if loaded modulefile corresponds to the explicitly defined
  default module version, the bare module name is recorded. If the configuration
  option *implicit_default* is enabled, the bare module name is also recorded
  for the implicit default module version. If
- **MODULES_COLLECTION_PIN_VERSION** is set to **1**, module version is always
+ :envvar:`MODULES_COLLECTION_PIN_VERSION` is set to **1**, module version is always
  recorded even if it is the default version.
 
  No *collection* is recorded and an error is returned if the loaded
@@ -518,17 +518,17 @@ Module Sub-Commands
  name is not specified, then it is assumed to be the *default* collection. If
  *collection* is a fully qualified path, it is restored from this location
  rather than from a file under the user's collection directory. If
- **MODULES_COLLECTION_TARGET** is set, a suffix equivalent to the value
+ :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
  of this variable is appended to the *collection* file name to restore.
 
- When restoring a *collection*, the currently set **MODULEPATH**
+ When restoring a *collection*, the currently set :envvar:`MODULEPATH`
  directory list and the currently loaded *modulefiles* are unused and
- unloaded then used and loaded to exactly match the **MODULEPATH** and
+ unloaded then used and loaded to exactly match the :envvar:`MODULEPATH` and
  loaded *modulefiles* lists saved in this *collection* file. The order
  of the paths and modulefiles set in *collection* is preserved when
  restoring. It means that currently loaded modules are unloaded to get
- the same **LOADEDMODULES** root than collection and currently used module
- paths are unused to get the same **MODULEPATH** root. Then missing module
+ the same :envvar:`LOADEDMODULES` root than collection and currently used module
+ paths are unused to get the same :envvar:`MODULEPATH` root. Then missing module
  paths are used and missing modulefiles are loaded.
 
  If a module, without a default version explicitly defined, is recorded in a
@@ -541,7 +541,7 @@ Module Sub-Commands
 
  Delete the *collection* file under the user's collection directory. If
  *collection* name is not specified, then it is assumed to be the *default*
- collection. If **MODULES_COLLECTION_TARGET** is set, a suffix equivalent to
+ collection. If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to
  the value of this variable will be appended to the *collection* file name.
 
 .. _saveshow:
@@ -551,7 +551,7 @@ Module Sub-Commands
  Display the content of *collection*. If *collection* name is not specified,
  then it is assumed to be the *default* collection. If *collection* is a
  fully qualified path, this location is displayed rather than a collection
- file under the user's collection directory. If **MODULES_COLLECTION_TARGET**
+ file under the user's collection directory. If :envvar:`MODULES_COLLECTION_TARGET`
  is set, a suffix equivalent to the value of this variable will be appended
  to the *collection* file name.
 
@@ -560,7 +560,7 @@ Module Sub-Commands
 **savelist** [-t|-l]
 
  List collections that are currently saved under the user's collection
- directory. If **MODULES_COLLECTION_TARGET** is set, only collections
+ directory. If :envvar:`MODULES_COLLECTION_TARGET` is set, only collections
  matching the target suffix will be displayed.
 
 .. _initadd:
@@ -702,7 +702,7 @@ Module Sub-Commands
 **is-used** [directory...]
 
  Returns a true value if any of the listed *directories* has been enabled in
- **MODULEPATH** or if any *directory* is enabled in case no argument is
+ :envvar:`MODULEPATH` or if any *directory* is enabled in case no argument is
  provided. Returns a false value otherwise. See **is-used** in the
  :ref:`modulefile(4)` man page for further explanation.
 
@@ -711,7 +711,7 @@ Module Sub-Commands
 **is-avail** modulefile...
 
  Returns a true value if any of the listed *modulefiles* exists in enabled
- **MODULEPATH**. Returns a false value otherwise. See **is-avail** in the
+ :envvar:`MODULEPATH`. Returns a false value otherwise. See **is-avail** in the
  :ref:`modulefile(4)` man page for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -753,51 +753,51 @@ Module Sub-Commands
 
  * advanced_version_spec: advanced module version specification to finely
    select modulefiles (defines environment variable
-   **MODULES_ADVANCED_VERSION_SPEC** when set
+   :envvar:`MODULES_ADVANCED_VERSION_SPEC` when set
  * auto_handling: automated module handling mode (defines
-   **MODULES_AUTO_HANDLING**)
+   :envvar:`MODULES_AUTO_HANDLING`)
  * avail_indepth: **avail** sub-command in depth search mode (defines
-   **MODULES_AVAIL_INDEPTH**)
+   :envvar:`MODULES_AVAIL_INDEPTH`)
  * avail_report_dir_sym: display symbolic versions targeting directories on
    **avail** sub-command
  * avail_report_mfile_sym: display symbolic versions targeting modulefiles on
    **avail** sub-command
  * collection_pin_version: register exact modulefile version in collection
-   (defines **MODULES_COLLECTION_PIN_VERSION**)
+   (defines :envvar:`MODULES_COLLECTION_PIN_VERSION`)
  * collection_target: collection target which is valid for current system
-   (defines **MODULES_COLLECTION_TARGET**)
- * color: colored output mode (defines **MODULES_COLOR**)
+   (defines :envvar:`MODULES_COLLECTION_TARGET`)
+ * color: colored output mode (defines :envvar:`MODULES_COLOR`)
  * colors: chosen colors to highlight output items (defines
-   **MODULES_COLORS**)
- * contact: modulefile contact address (defines **MODULECONTACT**)
+   :envvar:`MODULES_COLORS`)
+ * contact: modulefile contact address (defines :envvar:`MODULECONTACT`)
  * extended_default: allow partial module version specification (defines
-   **MODULES_EXTENDED_DEFAULT**)
+   :envvar:`MODULES_EXTENDED_DEFAULT`)
  * extra_siteconfig: additional site-specific configuration script location
-   (defines **MODULES_SITECONFIG**)
+   (defines :envvar:`MODULES_SITECONFIG`)
  * home: location of Modules package master directory (defines
-   **MODULESHOME**)
- * icase: enable case insensitive match (defines **MODULES_ICASE**)
+   :envvar:`MODULESHOME`)
+ * icase: enable case insensitive match (defines :envvar:`MODULES_ICASE`)
  * ignored_dirs: directories ignored when looking for modulefiles
  * implicit_default: set an implicit default version for modules (defines
-   **MODULES_IMPLICIT_DEFAULT**)
+   :envvar:`MODULES_IMPLICIT_DEFAULT`)
  * locked_configs: configuration options that cannot be superseded
- * pager: text viewer to paginate message output (defines **MODULES_PAGER**)
- * rcfile: global run-command file location (defines **MODULERCFILE**)
+ * pager: text viewer to paginate message output (defines :envvar:`MODULES_PAGER`)
+ * rcfile: global run-command file location (defines :envvar:`MODULERCFILE`)
  * run_quarantine: environment variables to indirectly pass to
-   :file:`modulecmd.tcl` (defines **MODULES_RUN_QUARANTINE**)
+   :file:`modulecmd.tcl` (defines :envvar:`MODULES_RUN_QUARANTINE`)
  * silent_shell_debug: disablement of shell debugging property for the module
-   command (defines **MODULES_SILENT_SHELL_DEBUG**)
- * search_match: module search match style (defines **MODULES_SEARCH_MATCH**)
+   command (defines :envvar:`MODULES_SILENT_SHELL_DEBUG`)
+ * search_match: module search match style (defines :envvar:`MODULES_SEARCH_MATCH`)
  * set_shell_startup: ensure module command definition by setting shell
-   startup file (defines **MODULES_SET_SHELL_STARTUP**)
+   startup file (defines :envvar:`MODULES_SET_SHELL_STARTUP`)
  * siteconfig: primary site-specific configuration script location
  * tcl_ext_lib: Modules Tcl extension library location
  * term_background: terminal background color kind (defines
-   **MODULES_TERM_BACKGROUND**)
+   :envvar:`MODULES_TERM_BACKGROUND`)
  * unload_match_order: unload firstly loaded or lastly loaded module matching
-   request (defines **MODULES_UNLOAD_MATCH_ORDER**)
- * verbosity: module command verbosity level (defines **MODULES_VERBOSITY**)
- * wa_277: workaround for Tcsh history issue (defines **MODULES_WA_277**)
+   request (defines :envvar:`MODULES_UNLOAD_MATCH_ORDER`)
+ * verbosity: module command verbosity level (defines :envvar:`MODULES_VERBOSITY`)
+ * wa_277: workaround for Tcsh history issue (defines :envvar:`MODULES_WA_277`)
 
 The options *avail_report_dir_sym*, *avail_report_mfile_sym*, *ignored_dirs*,
 *locked_configs*, *siteconfig* and *tcl_ext_lib* cannot be altered. Moreover
@@ -822,7 +822,7 @@ Advanced module version specifiers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 When the advanced module version specifiers mechanism is enabled (see
-**MODULES_ADVANCED_VERSION_SPEC**), the specification of modulefile passed on
+:envvar:`MODULES_ADVANCED_VERSION_SPEC`), the specification of modulefile passed on
 Modules sub-commands changes. After the module name a version constraint
 prefixed by the ``@`` character may be added. It could be directly appended to
 the module name or separated from it with a space character.
@@ -842,7 +842,7 @@ Constraints can be expressed to refine the selection of module version to:
 
 Advanced specification of single version or list of versions may benefit from
 the activation of the extended default mechanism (see
-**MODULES_EXTENDED_DEFAULT**) to use an abbreviated notation like ``@1`` to
+:envvar:`MODULES_EXTENDED_DEFAULT`) to use an abbreviated notation like ``@1`` to
 refer to more precise version numbers like ``1.2.3``. Range of versions on its
 side natively handles abbreviated versions.
 
@@ -869,7 +869,7 @@ default collections are saved under the :file:`$HOME/.module` directory.
 
 Collections may be valid for a given target if they are suffixed. In this
 case these collections can only be restored if their suffix correspond to
-the current value of the **MODULES_COLLECTION_TARGET** environment variable
+the current value of the :envvar:`MODULES_COLLECTION_TARGET` environment variable
 (see the dedicated section of this topic below).
 
 
@@ -896,15 +896,15 @@ ENVIRONMENT
 
  The path that the :command:`module` command searches when looking for
  *modulefiles*. Typically, it is set to the master *modulefiles* directory,
- |emph prefix|\ */modulefiles*, by the initialization script. **MODULEPATH**
+ |emph prefix|\ */modulefiles*, by the initialization script. :envvar:`MODULEPATH`
  can be set using **module use** or by the module initialization script
  to search group or personal *modulefile* directories before or after the
  master *modulefile* directory.
 
- Path elements registered in the **MODULEPATH** environment variable may
+ Path elements registered in the :envvar:`MODULEPATH` environment variable may
  contain reference to environment variables which are converted to their
  corresponding value by :command:`module` command each time it looks at the
- **MODULEPATH** value. If an environment variable referred in a path element
+ :envvar:`MODULEPATH` value. If an environment variable referred in a path element
  is not defined, its reference is converted to an empty string.
 
 .. envvar:: MODULERCFILE
@@ -925,9 +925,9 @@ ENVIRONMENT
  module version specifiers.
 
  Advanced module version specifiers enablement is defined in the following
- order of preference: **MODULES_ADVANCED_VERSION_SPEC** environment variable
+ order of preference: :envvar:`MODULES_ADVANCED_VERSION_SPEC` environment variable
  then the default set in :file:`modulecmd.tcl` script configuration. Which means
- **MODULES_ADVANCED_VERSION_SPEC** overrides default configuration.
+ :envvar:`MODULES_ADVANCED_VERSION_SPEC` overrides default configuration.
 
 .. envvar:: MODULES_AUTO_HANDLING
 
@@ -976,8 +976,8 @@ ENVIRONMENT
 
  Automated module handling mode enablement is defined in the following order
  of preference: **--auto**/**--no-auto** command line switches,
- then **MODULES_AUTO_HANDLING** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_AUTO_HANDLING**
+ then :envvar:`MODULES_AUTO_HANDLING` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AUTO_HANDLING`
  overrides default configuration and **--auto**/**--no-auto** command line
  switches override every other ways to enable or disable this mode.
 
@@ -994,8 +994,8 @@ ENVIRONMENT
 
  **avail** sub-command in depth mode enablement is defined in the following
  order of preference: **--indepth**/**--no-indepth** command line switches,
- then **MODULES_AVAIL_INDEPTH** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_AVAIL_INDEPTH**
+ then :envvar:`MODULES_AVAIL_INDEPTH` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AVAIL_INDEPTH`
  overrides default configuration and **--indepth**/**--no-indepth** command
  line switches override every other ways to enable or disable this mode.
 
@@ -1017,7 +1017,7 @@ ENVIRONMENT
 
  Collection directory may sometimes be shared on multiple machines which may
  use different modules setup. For instance modules users may access with the
- same **HOME** directory multiple systems using different OS versions. When
+ same :envvar:`HOME` directory multiple systems using different OS versions. When
  it happens a collection made on machine 1 may be erroneous on machine 2.
 
  When a target is set, only the collections made for that target are
@@ -1027,7 +1027,7 @@ ENVIRONMENT
  target is not involved when collection is specified as file path on the
  **saveshow**, **restore** and **save** sub-commands.
 
- For example, the **MODULES_COLLECTION_TARGET** variable may be set with
+ For example, the :envvar:`MODULES_COLLECTION_TARGET` variable may be set with
  results from commands like :command:`lsb_release`, :command:`hostname`, :command:`dnsdomainname`,
  etc.
 
@@ -1040,26 +1040,26 @@ ENVIRONMENT
  error output channel is attached to a terminal.
 
  Colored output enablement is defined in the following order of preference:
- **--color** command line switch, then **MODULES_COLOR** environment variable,
- then **CLICOLOR** and **CLICOLOR_FORCE** environment variables, then the
+ **--color** command line switch, then :envvar:`MODULES_COLOR` environment variable,
+ then :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables, then the
  default set in :file:`modulecmd.tcl` script configuration. Which means
- **MODULES_COLOR** overrides default configuration and the
- **CLICOLOR**/**CLICOLOR_FORCE** variables. **--color** command line switch
+ :envvar:`MODULES_COLOR` overrides default configuration and the
+ :envvar:`CLICOLOR`/:envvar:`CLICOLOR_FORCE` variables. **--color** command line switch
  overrides every other ways to enable or disable this mode.
 
- **CLICOLOR** and **CLICOLOR_FORCE** environment variables are also honored to
- define color mode. The *never* mode is set if **CLICOLOR** equals to **0**.
- If **CLICOLOR** is set to another value, it corresponds to the *auto* mode.
- The *always* mode is set if **CLICOLOR_FORCE** is set to a value different
+ :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables are also honored to
+ define color mode. The *never* mode is set if :envvar:`CLICOLOR` equals to **0**.
+ If :envvar:`CLICOLOR` is set to another value, it corresponds to the *auto* mode.
+ The *always* mode is set if :envvar:`CLICOLOR_FORCE` is set to a value different
  than **0**. Color mode set with these two variables is superseded by mode set
- with **MODULES_COLOR** environment variable.
+ with :envvar:`MODULES_COLOR` environment variable.
 
 .. envvar:: MODULES_COLORS
 
  Specifies the colors and other attributes used to highlight various parts of
  the output. Its value is a colon-separated list of output items associated to
  a Select Graphic Rendition (SGR) code. It follows the same syntax than
- **LS_COLORS**.
+ :envvar:`LS_COLORS`.
 
  Output items are designated by keys. Items able to be colorized are:
  highlighted element (*hi*), debug information (*db*), tag separator (*se*);
@@ -1080,11 +1080,11 @@ ENVIRONMENT
 
  No graphical rendition will be applied to an output item that could normaly
  be colored but which is not defined in the color set. Thus if
- **MODULES_COLORS** is defined empty, no output will be colored at all.
+ :envvar:`MODULES_COLORS` is defined empty, no output will be colored at all.
 
  The color set is defined for Modules in the following order of preference:
- **MODULES_COLORS** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_COLORS**
+ :envvar:`MODULES_COLORS` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_COLORS`
  overrides default configuration.
 
 .. envvar:: MODULES_EXTENDED_DEFAULT
@@ -1098,7 +1098,7 @@ ENVIRONMENT
  In case multiple modulefiles match the specified module version and a single
  module has to be selected, the explicitly set default version is returned if it
  is part of matching modulefiles. Otherwise the implicit default among matching
- modulefiles is returned if defined (see **MODULES_IMPLICIT_DEFAULT** section)
+ modulefiles is returned if defined (see :envvar:`MODULES_IMPLICIT_DEFAULT` section)
 
  This environment variable supersedes the value of the configuration option
  *extended_default* set in :file:`modulecmd.tcl` script.
@@ -1107,7 +1107,7 @@ ENVIRONMENT
 
  When module specification are passed as argument to module sub-commands or
  modulefile Tcl commands, defines the case sensitiveness to apply to match
- them. When **MODULES_ICASE** is set to **never**, a case sensitive match is
+ them. When :envvar:`MODULES_ICASE` is set to **never**, a case sensitive match is
  applied in any cases. When set to **search**, a case insensitive match is
  applied to the **avail**, **whatis** and **paths** sub-commands. When set to
  **always**, a case insensitive match is also applied to the other module
@@ -1116,8 +1116,8 @@ ENVIRONMENT
 
  Case sensitiveness behavior is defined in the following order of preference:
  **--icase** command line switch, which corresponds to the **always** mode,
- then **MODULES_ICASE** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_ICASE**
+ then :envvar:`MODULES_ICASE` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_ICASE`
  overrides default configuration and **--icase** command line switch overrides
  every other ways to set case sensitiveness behavior.
 
@@ -1138,7 +1138,7 @@ ENVIRONMENT
    order.
 
  * automatically loaded by automated module handling mechanisms (see
-   **MODULES_AUTO_HANDLING** section) when declared as module requirement,
+   :envvar:`MODULES_AUTO_HANDLING` section) when declared as module requirement,
    with **prereq** or **module load** modulefile commands.
 
  An error is returned in the above situations if either no explicit or
@@ -1209,17 +1209,17 @@ ENVIRONMENT
  command name or path eventually followed by command-line options.
 
  Paging command and options are defined for Modules in the following order of
- preference: **MODULES_PAGER** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_PAGER**
+ preference: :envvar:`MODULES_PAGER` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_PAGER`
  overrides default configuration.
 
- If **MODULES_PAGER** variable is set to an empty string or to the value
+ If :envvar:`MODULES_PAGER` variable is set to an empty string or to the value
  *cat*, pager will not be launched.
 
 .. envvar:: MODULES_RUNENV_<VAR>
 
- Value to set to environment variable *<VAR>* for :file:`modulecmd.tcl` run-time
- execution if *<VAR>* is referred in **MODULES_RUN_QUARANTINE**.
+ Value to set to environment variable :envvar:`<VAR>` for :file:`modulecmd.tcl` run-time
+ execution if :envvar:`<VAR>` is referred in :envvar:`MODULES_RUN_QUARANTINE`.
 
 .. envvar:: MODULES_RUN_QUARANTINE
 
@@ -1227,12 +1227,12 @@ ENVIRONMENT
  indirectly to :file:`modulecmd.tcl` to protect its run-time environment from
  side-effect coming from their current definition.
 
- Each variable found in **MODULES_RUN_QUARANTINE** will have its value emptied
- or set to the value of the corresponding **MODULES_RUNENV_<VAR>** variable
+ Each variable found in :envvar:`MODULES_RUN_QUARANTINE` will have its value emptied
+ or set to the value of the corresponding :envvar:`MODULES_RUNENV_<VAR>` variable
  when defining :file:`modulecmd.tcl` run-time environment.
 
  Original values of these environment variables set in quarantine are passed
- to :file:`modulecmd.tcl` via **<VAR>_modquar** variables.
+ to :file:`modulecmd.tcl` via :envvar:`<VAR>_modquar` variables.
 
 .. envvar:: MODULES_SEARCH_MATCH
 
@@ -1244,8 +1244,8 @@ ENVIRONMENT
 
  Module search match style is defined in the following order of preference:
  **--starts-with** and **--contains** command line switches, then
- **MODULES_SEARCH_MATCH** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_SEARCH_MATCH**
+ :envvar:`MODULES_SEARCH_MATCH` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_SEARCH_MATCH`
  overrides default configuration and **--starts-with**/**--contains** command
  line switches override every other ways to set search match style.
 
@@ -1253,8 +1253,8 @@ ENVIRONMENT
 
  If set to **1**, defines when :command:`module` command initializes the shell
  startup file to ensure that the :command:`module` command is still defined in
- sub-shells. Setting shell startup file means defining the **ENV** and
- **BASH_ENV** environment variable to the Modules bourne shell initialization
+ sub-shells. Setting shell startup file means defining the :envvar:`ENV` and
+ :envvar:`BASH_ENV` environment variable to the Modules bourne shell initialization
  script. If set to **0**, shell startup file is not defined.
 
 .. envvar:: MODULES_SILENT_SHELL_DEBUG
@@ -1277,7 +1277,7 @@ ENVIRONMENT
  Inform Modules of the terminal background color to determine if the color set
  for dark background or the color set for light background should be used to
  color output in case no specific color set is defined with the
- **MODULES_COLORS** variable. Accepted values are **dark** and **light**.
+ :envvar:`MODULES_COLORS` variable. Accepted values are **dark** and **light**.
 
 .. envvar:: MODULES_UNLOAD_MATCH_ORDER
 
@@ -1312,8 +1312,8 @@ ENVIRONMENT
 
  Module command verbosity is defined in the following order of preference:
  **--silent**, **--verbose** and **--debug** command line switches, then
- **MODULES_VERBOSITY** environment variable, then the default set in
- :file:`modulecmd.tcl` script configuration. Which means **MODULES_VERBOSITY**
+ :envvar:`MODULES_VERBOSITY` environment variable, then the default set in
+ :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_VERBOSITY`
  overrides default configuration and **--silent**/**--verbose**/**--debug**
  command line switches overrides every other ways to set verbosity level.
 
@@ -1335,15 +1335,15 @@ ENVIRONMENT
 
 .. envvar:: <VAR>_modquar
 
- Value of environment variable *<VAR>* passed to :file:`modulecmd.tcl` in order
- to restore *<VAR>* to this value once started.
+ Value of environment variable :envvar:`<VAR>` passed to :file:`modulecmd.tcl` in order
+ to restore :envvar:`<VAR>` to this value once started.
 
 .. envvar:: <VAR>_modshare
 
- Reference counter variable for path-like variable *<VAR>*. A colon
+ Reference counter variable for path-like variable :envvar:`<VAR>`. A colon
  separated list containing pairs of elements. A pair is formed by a path
  element followed its usage counter which represents the number of times
- this path has been enabled in variable *<VAR>*. A colon separates the
+ this path has been enabled in variable :envvar:`<VAR>`. A colon separates the
  two parts of the pair.
 
 
@@ -1352,18 +1352,18 @@ FILES
 
 |bold prefix|
 
- The **MODULESHOME** directory.
+ The :envvar:`MODULESHOME` directory.
 
 |bold etcdir|\ **/siteconfig.tcl**
 
  The site-specific configuration script of :file:`modulecmd.tcl`. An additional
- configuration script could be defined using the **MODULES_SITECONFIG**
+ configuration script could be defined using the :envvar:`MODULES_SITECONFIG`
  environment variable.
 
 |bold etcdir|\ **/rc**
 
  The system-wide modules rc file. The location of this file can be changed
- using the **MODULERCFILE** environment variable as described above.
+ using the :envvar:`MODULERCFILE` environment variable as described above.
 
 :file:`$HOME/.modulerc`
 
@@ -1376,7 +1376,7 @@ FILES
 |bold modulefilesdir|
 
  The directory for system-wide *modulefiles*. The location of the directory
- can be changed using the **MODULEPATH** environment variable as described
+ can be changed using the :envvar:`MODULEPATH` environment variable as described
  above.
 
 |bold libexecdir|\ **/modulecmd.tcl**

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -246,9 +246,7 @@ switches are accepted:
 Module Sub-Commands
 ^^^^^^^^^^^^^^^^^^^
 
-.. _help:
-
-**help** [modulefile...]
+.. subcmd:: help [modulefile...]
 
  Print the usage of each sub-command. If an argument is given, print the
  Module-specific help information for the *modulefile*.
@@ -257,15 +255,11 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _add:
-
-**add** modulefile...
+.. subcmd:: add modulefile...
 
  See **load**.
 
-.. _load:
-
-**load** [--auto|--no-auto] [-f] modulefile...
+.. subcmd:: load [--auto|--no-auto] [-f] modulefile...
 
  Load *modulefile* into the shell environment.
 
@@ -273,15 +267,11 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _rm:
-
-**rm** modulefile...
+.. subcmd:: rm modulefile...
 
  See **unload**.
 
-.. _unload:
-
-**unload** [--auto|--no-auto] [-f] modulefile...
+.. subcmd:: unload [--auto|--no-auto] [-f] modulefile...
 
  Remove *modulefile* from the shell environment.
 
@@ -289,15 +279,11 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _swap:
-
-**swap** [modulefile1] modulefile2
+.. subcmd:: swap [modulefile1] modulefile2
 
  See **switch**.
 
-.. _switch:
-
-**switch** [--auto|--no-auto] [-f] [modulefile1] modulefile2
+.. subcmd:: switch [--auto|--no-auto] [-f] [modulefile1] modulefile2
 
  Switch loaded *modulefile1* with *modulefile2*. If *modulefile1* is not
  specified, then it is assumed to be the currently loaded module with the
@@ -307,15 +293,11 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _show:
-
-**show** modulefile...
+.. subcmd:: show modulefile...
 
  See **display**.
 
-.. _display:
-
-**display** modulefile...
+.. subcmd:: display modulefile...
 
  Display information about one or more *modulefiles*. The display sub-command
  will list the full path of the *modulefile* and the environment changes
@@ -326,15 +308,11 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _list:
-
-**list** [-t|-l]
+.. subcmd:: list [-t|-l]
 
  List loaded modules.
 
-.. _avail:
-
-**avail** [-d|-L] [-t|-l] [-S|-C] [--indepth|--no-indepth] [path...]
+.. subcmd:: avail [-d|-L] [-t|-l] [-S|-C] [--indepth|--no-indepth] [path...]
 
  List all available *modulefiles* in the current :envvar:`MODULEPATH`. All
  directories in the :envvar:`MODULEPATH` are recursively searched for files
@@ -365,18 +343,14 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _aliases:
-
-**aliases**
+.. subcmd:: aliases
 
  List all available symbolic version-names and aliases in the current
  :envvar:`MODULEPATH`.  All directories in the :envvar:`MODULEPATH` are recursively
  searched in the same manner than for the **avail** sub-command. Only the
  symbolic version-names and aliases found in the search are displayed.
 
-.. _use:
-
-**use** [-a|--append] directory...
+.. subcmd:: use [-a|--append] directory...
 
  Prepend one or more *directories* to the :envvar:`MODULEPATH` environment
  variable.  The ``--append`` flag will append the *directory* to
@@ -386,9 +360,7 @@ Module Sub-Commands
  also set to increase the number of times *directory* has been added to
  :envvar:`MODULEPATH`.
 
-.. _unuse:
-
-**unuse** directory...
+.. subcmd:: unuse directory...
 
  Remove one or more *directories* from the :envvar:`MODULEPATH` environment
  variable if reference counter of these *directories* is equal to 1
@@ -401,15 +373,11 @@ Module Sub-Commands
  equal to 1 or not defined. Otherwise *directory* is kept and reference
  counter is decreased by 1.
 
-.. _refresh:
-
-**refresh**
+.. subcmd:: refresh
 
  See **reload**.
 
-.. _reload:
-
-**reload**
+.. subcmd:: reload
 
  Unload then load all loaded *modulefiles*.
 
@@ -417,32 +385,24 @@ Module Sub-Commands
  *modulefiles* have unsatisfied constraint corresponding to the **prereq**
  and **conflict** they declare.
 
-.. _purge:
-
-**purge**
+.. subcmd:: purge
 
  Unload all loaded *modulefiles*.
 
-.. _clear:
-
-**clear** [-f]
+.. subcmd:: clear [-f]
 
  Force the Modules package to believe that no modules are currently loaded. A
  confirmation is requested if command-line switch :option:`-f` (or :option:`--force`) is not
  passed. Typed confirmation should equal to *yes* or *y* in order to proceed.
 
-.. _source:
-
-**source** scriptfile...
+.. subcmd:: source scriptfile...
 
  Execute *scriptfile* into the shell environment. *scriptfile* must be written
  with *modulefile* syntax and specified with a fully qualified path. Once
  executed *scriptfile* is not marked loaded in shell environment which differ
  from **load** sub-command.
 
-.. _whatis:
-
-**whatis** [modulefile...]
+.. subcmd:: whatis [modulefile...]
 
  Display the information set up by the **module-whatis** commands inside
  the specified *modulefiles*. These specified *modulefiles* may be
@@ -453,30 +413,22 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _apropos:
-
-**apropos** string
+.. subcmd:: apropos string
 
  See **search**.
 
-.. _keyword:
-
-**keyword** string
+.. subcmd:: keyword string
 
  See **search**.
 
-.. _search-cmd:
-
-**search** string
+.. subcmd:: search string
 
  Seeks through the **module-whatis** informations of all *modulefiles* for the
  specified *string*. All *module-whatis* informations matching the *string* in
  a case insensitive manner will be displayed. *string* may contain wildcard
  characters.
 
-.. _test:
-
-**test** modulefile...
+.. subcmd:: test modulefile...
 
  Execute and display results of the Module-specific tests for the
  *modulefile*.
@@ -485,9 +437,7 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _save:
-
-**save** [collection]
+.. subcmd:: save [collection]
 
  Record the currently set :envvar:`MODULEPATH` directory list and the currently
  loaded *modulefiles* in a *collection* file under the user's collection
@@ -510,9 +460,7 @@ Module Sub-Commands
  *modulefiles* have unsatisfied constraint corresponding to the **prereq**
  and **conflict** they declare.
 
-.. _restore:
-
-**restore** [collection]
+.. subcmd:: restore [collection]
 
  Restore the environment state as defined in *collection*. If *collection*
  name is not specified, then it is assumed to be the *default* collection. If
@@ -535,18 +483,14 @@ Module Sub-Commands
  *collection* by its bare name: loading this module when restoring the
  collection will fail if the configuration option *implicit_default* is disabled.
 
-.. _saverm:
-
-**saverm** [collection]
+.. subcmd:: saverm [collection]
 
  Delete the *collection* file under the user's collection directory. If
  *collection* name is not specified, then it is assumed to be the *default*
  collection. If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to
  the value of this variable will be appended to the *collection* file name.
 
-.. _saveshow:
-
-**saveshow** [collection]
+.. subcmd:: saveshow [collection]
 
  Display the content of *collection*. If *collection* name is not specified,
  then it is assumed to be the *default* collection. If *collection* is a
@@ -555,17 +499,13 @@ Module Sub-Commands
  is set, a suffix equivalent to the value of this variable will be appended
  to the *collection* file name.
 
-.. _savelist:
-
-**savelist** [-t|-l]
+.. subcmd:: savelist [-t|-l]
 
  List collections that are currently saved under the user's collection
  directory. If :envvar:`MODULES_COLLECTION_TARGET` is set, only collections
  matching the target suffix will be displayed.
 
-.. _initadd:
-
-**initadd** modulefile...
+.. subcmd:: initadd modulefile...
 
  Add *modulefile* to the shell's initialization file in the user's home
  directory. The startup files checked (in order) are:
@@ -600,40 +540,28 @@ Module Sub-Commands
  the **init** sub-commands to work properly. If the **module load** line is
  found in multiple shell initialization files, all of the lines are changed.
 
-.. _initprepend:
-
-**initprepend** modulefile...
+.. subcmd:: initprepend modulefile...
 
  Does the same as **initadd** but prepends the given modules to the
  beginning of the list.
 
-.. _initrm:
-
-**initrm** modulefile...
+.. subcmd:: initrm modulefile...
 
  Remove *modulefile* from the shell's initialization files.
 
-.. _initswitch:
-
-**initswitch** modulefile1 modulefile2
+.. subcmd:: initswitch modulefile1 modulefile2
 
  Switch *modulefile1* with *modulefile2* in the shell's initialization files.
 
-.. _initlist:
-
-**initlist**
+.. subcmd:: initlist
 
  List all of the *modulefiles* loaded from the shell's initialization file.
 
-.. _initclear:
-
-**initclear**
+.. subcmd:: initclear
 
  Clear all of the *modulefiles* from the shell's initialization files.
 
-.. _path:
-
-**path** modulefile
+.. subcmd:: path modulefile
 
  Print path to *modulefile*.
 
@@ -641,9 +569,7 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _paths:
-
-**paths** modulefile
+.. subcmd:: paths modulefile
 
  Print path of available *modulefiles* matching argument.
 
@@ -651,33 +577,25 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _append-path:
-
-**append-path** [-d C|--delim C|--delim=C] [--duplicates] variable value...
+.. subcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Append *value* to environment *variable*. The *variable* is a colon, or
  *delimiter*, separated list. See **append-path** in the :ref:`modulefile(4)`
  man page for further explanation.
 
-.. _prepend-path:
-
-**prepend-path** [-d C|--delim C|--delim=C] [--duplicates] variable value...
+.. subcmd:: prepend-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Prepend *value* to environment *variable*. The *variable* is a colon, or
  *delimiter*, separated list. See **prepend-path** in the :ref:`modulefile(4)`
  man page for further explanation.
 
-.. _remove-path:
-
-**remove-path** [-d C|--delim C|--delim=C] [--index] variable value...
+.. subcmd:: remove-path [-d C|--delim C|--delim=C] [--index] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in environment
  *variable*. See **remove-path** in the :ref:`modulefile(4)` man page for
  further explanation.
 
-.. _is-loaded:
-
-**is-loaded** [modulefile...]
+.. subcmd:: is-loaded [modulefile...]
 
  Returns a true value if any of the listed *modulefiles* has been loaded or if
  any *modulefile* is loaded in case no argument is provided. Returns a false
@@ -688,27 +606,21 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _is-saved:
-
-**is-saved** [collection...]
+.. subcmd:: is-saved [collection...]
 
  Returns a true value if any of the listed *collections* exists or if any
  *collection* exists in case no argument is provided. Returns a false value
  otherwise. See **is-saved** in the :ref:`modulefile(4)` man page for further
  explanation.
 
-.. _is-used:
-
-**is-used** [directory...]
+.. subcmd:: is-used [directory...]
 
  Returns a true value if any of the listed *directories* has been enabled in
  :envvar:`MODULEPATH` or if any *directory* is enabled in case no argument is
  provided. Returns a false value otherwise. See **is-used** in the
  :ref:`modulefile(4)` man page for further explanation.
 
-.. _is-avail:
-
-**is-avail** modulefile...
+.. subcmd:: is-avail modulefile...
 
  Returns a true value if any of the listed *modulefiles* exists in enabled
  :envvar:`MODULEPATH`. Returns a false value otherwise. See **is-avail** in the
@@ -718,18 +630,14 @@ Module Sub-Commands
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _info-loaded:
-
-**info-loaded** modulefile
+.. subcmd:: info-loaded modulefile
 
  Returns the names of currently loaded modules matching passed *modulefile*.
  Returns an empty string if passed *modulefile* does not match any loaded
  modules. See **module-info loaded** in the :ref:`modulefile(4)` man page for
  further explanation.
 
-.. _config:
-
-**config** [--dump-state|name [value]|--reset name]
+.. subcmd:: config [--dump-state|name [value]|--reset name]
 
  Gets or sets :file:`modulecmd.tcl` options. Reports the currently set value of
  passed option *name* or all existing options if no *name* passed. If a *name*

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -379,7 +379,7 @@ Module Sub-Commands
 **use** [-a|--append] directory...
 
  Prepend one or more *directories* to the :envvar:`MODULEPATH` environment
- variable.  The *--append* flag will append the *directory* to
+ variable.  The ``--append`` flag will append the *directory* to
  :envvar:`MODULEPATH`.
 
  Reference counter environment variable :envvar:`MODULEPATH_modshare<\<VAR\>_modshare>` is
@@ -428,7 +428,7 @@ Module Sub-Commands
 **clear** [-f]
 
  Force the Modules package to believe that no modules are currently loaded. A
- confirmation is requested if command-line switch *-f* (or *--force*) is not
+ confirmation is requested if command-line switch :option:`-f` (or :option:`--force`) is not
  passed. Typed confirmation should equal to *yes* or *y* in order to proceed.
 
 .. _source:
@@ -734,7 +734,7 @@ Module Sub-Commands
  Gets or sets :file:`modulecmd.tcl` options. Reports the currently set value of
  passed option *name* or all existing options if no *name* passed. If a *name*
  and a *value* are provided, the value of option *name* is set to *value*. If
- command-line switch *--reset* is passed in addition to a *name*, overridden
+ command-line switch ``--reset`` is passed in addition to a *name*, overridden
  overridden value for option *name* is cleared.
 
  When a reported option value differs from default value a mention is added
@@ -745,7 +745,7 @@ Module Sub-Commands
  If no value is currently set for an option *name*, the mention *<undef>* is
  reported.
 
- When command-line switch *--dump-state* is passed, current :file:`modulecmd.tcl`
+ When command-line switch ``--dump-state`` is passed, current :file:`modulecmd.tcl`
  state and Modules-related environment variables are reported in addition to
  currently set :file:`modulecmd.tcl` options.
 
@@ -975,10 +975,10 @@ ENVIRONMENT
  load of the switched-to modulefile.
 
  Automated module handling mode enablement is defined in the following order
- of preference: **--auto**/**--no-auto** command line switches,
+ of preference: :option:`--auto`/:option:`--no-auto` command line switches,
  then :envvar:`MODULES_AUTO_HANDLING` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AUTO_HANDLING`
- overrides default configuration and **--auto**/**--no-auto** command line
+ overrides default configuration and :option:`--auto`/:option:`--no-auto` command line
  switches override every other ways to enable or disable this mode.
 
 .. envvar:: MODULES_AVAIL_INDEPTH
@@ -993,10 +993,10 @@ ENVIRONMENT
  are excluded.
 
  **avail** sub-command in depth mode enablement is defined in the following
- order of preference: **--indepth**/**--no-indepth** command line switches,
+ order of preference: :option:`--indepth`/:option:`--no-indepth` command line switches,
  then :envvar:`MODULES_AVAIL_INDEPTH` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_AVAIL_INDEPTH`
- overrides default configuration and **--indepth**/**--no-indepth** command
+ overrides default configuration and :option:`--indepth`/:option:`--no-indepth` command
  line switches override every other ways to enable or disable this mode.
 
 .. envvar:: MODULES_CMD
@@ -1040,11 +1040,11 @@ ENVIRONMENT
  error output channel is attached to a terminal.
 
  Colored output enablement is defined in the following order of preference:
- **--color** command line switch, then :envvar:`MODULES_COLOR` environment variable,
+ :option:`--color` command line switch, then :envvar:`MODULES_COLOR` environment variable,
  then :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables, then the
  default set in :file:`modulecmd.tcl` script configuration. Which means
  :envvar:`MODULES_COLOR` overrides default configuration and the
- :envvar:`CLICOLOR`/:envvar:`CLICOLOR_FORCE` variables. **--color** command line switch
+ :envvar:`CLICOLOR`/:envvar:`CLICOLOR_FORCE` variables. :option:`--color` command line switch
  overrides every other ways to enable or disable this mode.
 
  :envvar:`CLICOLOR` and :envvar:`CLICOLOR_FORCE` environment variables are also honored to
@@ -1115,10 +1115,10 @@ ENVIRONMENT
  receive as argument.
 
  Case sensitiveness behavior is defined in the following order of preference:
- **--icase** command line switch, which corresponds to the **always** mode,
+ :option:`--icase` command line switch, which corresponds to the **always** mode,
  then :envvar:`MODULES_ICASE` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_ICASE`
- overrides default configuration and **--icase** command line switch overrides
+ overrides default configuration and :option:`--icase` command line switch overrides
  every other ways to set case sensitiveness behavior.
 
 .. envvar:: MODULES_IMPLICIT_DEFAULT
@@ -1243,10 +1243,10 @@ ENVIRONMENT
  search query string are returned.
 
  Module search match style is defined in the following order of preference:
- **--starts-with** and **--contains** command line switches, then
+ :option:`--starts-with` and :option:`--contains` command line switches, then
  :envvar:`MODULES_SEARCH_MATCH` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_SEARCH_MATCH`
- overrides default configuration and **--starts-with**/**--contains** command
+ overrides default configuration and :option:`--starts-with`/:option:`--contains` command
  line switches override every other ways to set search match style.
 
 .. envvar:: MODULES_SET_SHELL_STARTUP
@@ -1311,10 +1311,10 @@ ENVIRONMENT
  * debug: print debugging messages about module command execution.
 
  Module command verbosity is defined in the following order of preference:
- **--silent**, **--verbose** and **--debug** command line switches, then
+ :option:`--silent`, :option:`--verbose` and :option:`--debug` command line switches, then
  :envvar:`MODULES_VERBOSITY` environment variable, then the default set in
  :file:`modulecmd.tcl` script configuration. Which means :envvar:`MODULES_VERBOSITY`
- overrides default configuration and **--silent**/**--verbose**/**--debug**
+ overrides default configuration and :option:`--silent`/:option:`--verbose`/:option:`--debug`
  command line switches overrides every other ways to set verbosity level.
 
 .. envvar:: MODULES_WA_277

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -306,12 +306,12 @@ the *modulefile* is being loaded.
 
  Contains the same *sub-commands* as described in the :ref:`module(1)`
  man page in the Module Sub-Commands section. This command permits a
- *modulefile* to **load** or **unload** other *modulefiles*. No checks are
+ *modulefile* to :subcmd:`load` or :subcmd:`unload` other *modulefiles*. No checks are
  made to ensure that the *modulefile* does not try to load itself. Often
  it is useful to have a single *modulefile* that performs a number of
- **module load** commands. For example, if every user on the system
+ ``module load`` commands. For example, if every user on the system
  requires a basic set of applications loaded, then a core *modulefile*
- would contain the necessary **module load** commands.
+ would contain the necessary ``module load`` commands.
 
  Command line switches :option:`--auto`, :option:`--no-auto` and :option:`--force` are ignored
  when passed to a **module** command set in a *modulefile*.
@@ -464,9 +464,9 @@ the *modulefile* is being loaded.
 **module-whatis** string
 
  Defines a string which is displayed in case of the invocation of the
- **module whatis** command. There may be more than one **module-whatis**
- line in a *modulefile*. This command takes no actions in case of **load**,
- **display**, etc. invocations of :file:`modulecmd.tcl`.
+ :subcmd:`module whatis<whatis>` command. There may be more than one **module-whatis**
+ line in a *modulefile*. This command takes no actions in case of :subcmd:`load`,
+ :subcmd:`display`, etc. invocations of :file:`modulecmd.tcl`.
 
  The *string* parameter has to be enclosed in double-quotes if there's more
  than one word specified. Words are defined to be separated by whitespace
@@ -714,7 +714,7 @@ Modulefile Specific Help
 Users can request help about a specific *modulefile* through the
 :ref:`module(1)` command. The *modulefile* can print helpful information or
 start help oriented programs by defining a **ModulesHelp** subroutine. The
-subroutine will be called when the **module help modulefile** command
+subroutine will be called when the :subcmd:`module help modulefile<help>` command
 is used.
 
 
@@ -724,7 +724,7 @@ Modulefile Specific Test
 Users can request test of a specific *modulefile* through the :ref:`module(1)`
 command. The *modulefile* can perform some sanity checks on its
 definition or on its underlying programs by defining a **ModulesTest**
-subroutine. The subroutine will be called when the **module test modulefile**
+subroutine. The subroutine will be called when the :subcmd:`module test modulefile<test>`
 command is used. The subroutine should return 1 in case of success. If no
 or any other value is returned, test is considered failed.
 
@@ -732,7 +732,7 @@ or any other value is returned, test is considered failed.
 Modulefile Display
 ------------------
 
-The **module display modulefile** command will detail all changes that
+The :subcmd:`module display modulefile<display>` command will detail all changes that
 will be made to the environment. After displaying all of the environment
 changes :file:`modulecmd.tcl` will call the **ModulesDisplay** subroutine. The
 **ModulesDisplay** subroutine is a good place to put additional descriptive

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -574,6 +574,7 @@ Modules Variables
 The **ModulesCurrentModulefile** variable contains the full pathname of
 the *modulefile* being interpreted.
 
+.. _Locating Modulefiles:
 
 Locating Modulefiles
 --------------------

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -13,7 +13,7 @@ interface. *modulefiles* can be loaded, unloaded, or switched on-the-fly
 while the user is working; and can be used to implement site policies
 regarding the access and use of applications.
 
-A *modulefile* begins with the magic cookie, '#%Module'. A version number may
+A *modulefile* begins with the magic cookie, ``#%Module``. A version number may
 be placed after this string. The version number is useful as the *modulefile*
 format may change thus it reflects the minimum version of :file:`modulecmd.tcl`
 required to interpret the modulefile. If a version number doesn't exist, then
@@ -122,10 +122,10 @@ the *modulefile* is being loaded.
  Set environment *variable* to *value*. The :mfcmd:`setenv` command will also
  change the process' environment. A reference using Tcl's env associative
  array will reference changes made with the :mfcmd:`setenv` command. Changes
- made using Tcl's *env* associative array will **NOT** change the user's
+ made using Tcl's ``env`` associative array will **NOT** change the user's
  environment *variable* like the :mfcmd:`setenv` command. An environment change
  made this way will only affect the module parsing process. The :mfcmd:`setenv`
- command is also useful for changing the environment prior to the **exec**
+ command is also useful for changing the environment prior to the ``exec``
  or :mfcmd:`system` command. When a *modulefile* is unloaded, :mfcmd:`setenv` becomes
  :mfcmd:`unsetenv`. If the environment *variable* had been defined it will
  be overwritten while loading the *modulefile*. A subsequent :subcmd:`unload`
@@ -140,9 +140,9 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: getenv variable [value]
 
- Returns value of environment *variable*. If *variable* is not defined *value*
- is returned if set *_UNDEFINED_* is returned otherwise. :mfcmd:`getenv` command
- should be preferred over Tcl global variable **env** to query environment
+ Returns value of environment *variable*. If *variable* is not defined, *value*
+ is returned if set, ``_UNDEFINED_`` is returned otherwise. The :mfcmd:`getenv` command
+ should be preferred over the Tcl global variable ``env`` to query environment
  variables.
 
 .. mfcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
@@ -154,15 +154,15 @@ the *modulefile* is being loaded.
  Append or prepend *value* to environment *variable*. The
  *variable* is a colon, or *delimiter*, separated list such as
  ``PATH=directory:directory:directory``. The default delimiter is a colon
- ':', but an arbitrary one can be given by the ``--delim`` option. For
+ ``:``, but an arbitrary one can be given by the ``--delim`` option. For
  example a space can be used instead (which will need to be handled in
- the Tcl specially by enclosing it in " " or { }). A space, however,
- can not be specified by the *--delim=C* form.
+ the Tcl specially by enclosing it in ``" "`` or ``{ }``). A space, however,
+ can not be specified by the ``--delim=C`` form.
 
  A reference counter environment variable is also set to increase the
  number of times *value* has been added to environment *variable*. This
  reference counter environment variable is named by suffixing *variable*
- by *_modshare*.
+ by ``_modshare``.
 
  When *value* is already defined in environement *variable*, it is not added
  again except if ``--duplicates`` option is set.
@@ -291,8 +291,8 @@ the *modulefile* is being loaded.
 
  **module-info type**
 
-  Returns either "C" or "Tcl" to indicate which :command:`module` command is being
-  executed, either the "C" version or the Tcl-only version, to allow the
+  Returns either ``C`` or ``Tcl`` to indicate which :command:`module` command is being
+  executed, either the C version or the Tcl-only version, to allow the
   *modulefile* writer to handle any differences between the two.
 
  **module-info mode** [modetype]
@@ -300,17 +300,17 @@ the *modulefile* is being loaded.
   Returns the current :file:`modulecmd.tcl`'s mode as a string if no *modetype*
   is given.
 
-  Returns 1 if :file:`modulecmd.tcl`'s mode is *modetype*. *modetype* can be:
-  load, unload, remove, switch, display, help, test or whatis.
+  Returns ``1`` if :file:`modulecmd.tcl`'s mode is *modetype*. *modetype* can be:
+  ``load``, ``unload``, ``remove``, ``switch``, ``display``, ``help``, ``test`` or ``whatis``.
 
  **module-info command** [commandname]
 
   Returns the currently running :file:`modulecmd.tcl`'s command as a string
   if no *commandname* is given.
 
-  Returns 1 if :file:`modulecmd.tcl`'s command is *commandname*. *commandname*
-  can be: load, unload, reload, source, switch, display, avail, aliases,
-  list, whatis, search, purge, restore, help or test.
+  Returns ``1`` if :file:`modulecmd.tcl`'s command is *commandname*. *commandname*
+  can be: ``load``, ``unload``, ``reload``, ``source``, ``switch``, ``display``, ``avail``, ``aliases``,
+  ``list``, ``whatis``, ``search``, ``purge``, ``restore``, ``help`` or ``test``.
 
  **module-info name**
 
@@ -328,9 +328,9 @@ the *modulefile* is being loaded.
   no *shellname* is given. The current shell is the first parameter of
   :file:`modulecmd.tcl`, which is normally hidden by the :command:`module` alias.
 
-  If a *shellname* is given, returns 1 if :file:`modulecmd.tcl`'s current shell
-  is *shellname*, returns 0 otherwise. *shellname* can be: sh, bash, ksh,
-  zsh, csh, tcsh, fish, tcl, perl, python, ruby, lisp, cmake, r.
+  If a *shellname* is given, returns ``1`` if :file:`modulecmd.tcl`'s current shell
+  is *shellname*, returns ``0`` otherwise. *shellname* can be: ``sh``, ``bash``, ``ksh``,
+  ``zsh``, ``csh``, ``tcsh``, ``fish``, ``tcl``, ``perl``, ``python``, ``ruby``, ``lisp``, ``cmake``, ``r``.
 
  **module-info shelltype** [shelltypename]
 
@@ -339,9 +339,9 @@ the *modulefile* is being loaded.
   first parameter of :file:`modulecmd.tcl`. The output reflects a shell type
   determining the shell syntax of the commands produced by :file:`modulecmd.tcl`.
 
-  If a *shelltypename* is given, returns 1 if :file:`modulecmd.tcl`'s current
-  shell type is *shelltypename*, returns 0 otherwise. *shelltypename*
-  can be: sh, csh, fish, tcl, perl, python, ruby, lisp, cmake, r.
+  If a *shelltypename* is given, returns ``1`` if :file:`modulecmd.tcl`'s current
+  shell type is *shelltypename*, returns ``0`` otherwise. *shelltypename*
+  can be: ``sh``, ``csh``, ``fish``, ``tcl``, ``perl``, ``python``, ``ruby``, ``lisp``, ``cmake``, ``r``.
 
  **module-info alias** name
 
@@ -460,25 +460,25 @@ the *modulefile* is being loaded.
 .. mfcmd:: uname field
 
  Provide lookup of system information. Most *field* information are retrieved
- from the **tcl_platform** array (see :manpage:`tclvars(n)` man page). Uname will
- return the string "unknown" if information is unavailable for the *field*.
+ from the ``tcl_platform`` array (see the :manpage:`tclvars(n)` man page). Uname will
+ return the string ``unknown`` if information is unavailable for the *field*.
 
- :mfcmd:`uname` will invoke :manpage:`uname(1)` command in order to get the operating
+ :mfcmd:`uname` will invoke the :manpage:`uname(1)` command in order to get the operating
  system version and :manpage:`domainname(1)` to figure out the name of the domain.
 
  *field* values are:
 
- * sysname: the operating system name
+ * ``sysname``: the operating system name
 
- * nodename: the hostname
+ * ``nodename``: the hostname
 
- * domain: the name of the domain
+ * ``domain``: the name of the domain
 
- * release: the operating system release
+ * ``release``: the operating system release
 
- * version: the operating system version
+ * ``version``: the operating system version
 
- * machine: a standard name that identifies the system's hardware
+ * ``machine``: a standard name that identifies the system's hardware
 
 .. mfcmd:: x-resource [resource-string|filename]
 
@@ -496,16 +496,16 @@ the *modulefile* is being loaded.
 
  Examples:
 
- **x-resource** /u2/staff/leif/.xres/Ileaf
+ ``x-resource /u2/staff/leif/.xres/Ileaf``
 
   The content of the *Ileaf* file is merged into the X11 resource database.
 
- **x-resource** [glob ~/.xres/ileaf]
+ ``x-resource [glob ~/.xres/ileaf]``
 
   The Tcl glob function is used to have the *modulefile* read different
   resource files for different users.
 
- **x-resource** {Ileaf.popup.saveUnder: True}
+ ``x-resource {Ileaf.popup.saveUnder: True}``
 
   Merge the Ileaf resource into the X11 resource database.
 
@@ -513,7 +513,7 @@ the *modulefile* is being loaded.
 Modules Variables
 -----------------
 
-The **ModulesCurrentModulefile** variable contains the full pathname of
+The ``ModulesCurrentModulefile`` variable contains the full pathname of
 the *modulefile* being interpreted.
 
 .. _Locating Modulefiles:
@@ -539,12 +539,12 @@ sourced. Otherwise the file :file:`.version` is looked up in the module director
 
 If the :file:`.version` file exists, it is opened and interpreted as Tcl code and
 takes precedence over a :file:`.modulerc` file in the same directory. If the Tcl
-variable **ModulesVersion** is set by the :file:`.version` file, :file:`modulecmd.tcl`
+variable ``ModulesVersion`` is set by the :file:`.version` file, :file:`modulecmd.tcl`
 will use the name as if it specifies a *modulefile* in this directory. This
-will become the default *modulefile* in this case. **ModulesVersion** cannot
+will become the default *modulefile* in this case. ``ModulesVersion`` cannot
 refer to a *modulefile* located in a different directory.
 
-If **ModulesVersion** is a directory, the search begins anew down that
+If ``ModulesVersion`` is a directory, the search begins anew down that
 directory. If the name does not match any files located in the current
 directory, the search continues through the remaining directories in
 :envvar:`MODULEPATH`.
@@ -655,7 +655,7 @@ Modulefile Specific Help
 
 Users can request help about a specific *modulefile* through the
 :ref:`module(1)` command. The *modulefile* can print helpful information or
-start help oriented programs by defining a **ModulesHelp** subroutine. The
+start help oriented programs by defining a ``ModulesHelp`` subroutine. The
 subroutine will be called when the :subcmd:`module help modulefile<help>` command
 is used.
 
@@ -665,7 +665,7 @@ Modulefile Specific Test
 
 Users can request test of a specific *modulefile* through the :ref:`module(1)`
 command. The *modulefile* can perform some sanity checks on its
-definition or on its underlying programs by defining a **ModulesTest**
+definition or on its underlying programs by defining a ``ModulesTest``
 subroutine. The subroutine will be called when the :subcmd:`module test modulefile<test>`
 command is used. The subroutine should return 1 in case of success. If no
 or any other value is returned, test is considered failed.
@@ -676,8 +676,8 @@ Modulefile Display
 
 The :subcmd:`module display modulefile<display>` command will detail all changes that
 will be made to the environment. After displaying all of the environment
-changes :file:`modulecmd.tcl` will call the **ModulesDisplay** subroutine. The
-**ModulesDisplay** subroutine is a good place to put additional descriptive
+changes :file:`modulecmd.tcl` will call the ``ModulesDisplay`` subroutine. The
+``ModulesDisplay`` subroutine is a good place to put additional descriptive
 information about the *modulefile*.
 
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -8,18 +8,18 @@ DESCRIPTION
 -----------
 
 *modulefiles* are written in the Tool Command Language, **Tcl**\ (n) and are
-interpreted by the **modulecmd.tcl** program via the :ref:`module(1)` user
+interpreted by the :file:`modulecmd.tcl` program via the :ref:`module(1)` user
 interface. *modulefiles* can be loaded, unloaded, or switched on-the-fly
 while the user is working; and can be used to implement site policies
 regarding the access and use of applications.
 
 A *modulefile* begins with the magic cookie, '#%Module'. A version number may
 be placed after this string. The version number is useful as the *modulefile*
-format may change thus it reflects the minimum version of **modulecmd.tcl**
+format may change thus it reflects the minimum version of :file:`modulecmd.tcl`
 required to interpret the modulefile. If a version number doesn't exist, then
-**modulecmd.tcl** will assume the *modulefile* is compatible. Files without
+:file:`modulecmd.tcl` will assume the *modulefile* is compatible. Files without
 the magic cookie or with a version number greater than the current version of
-**modulecmd.tcl** will not be interpreted.
+:file:`modulecmd.tcl` will not be interpreted.
 
 Each *modulefile* contains the changes to a user's environment needed to
 access an application. Tcl is a simple programming language which permits
@@ -30,7 +30,7 @@ use all the extended commands provided by tclX, too.
 
 A typical *modulefile* is a simple bit of code that set or add entries
 to the **PATH**, **MANPATH**, or other environment variables. A Modulefile is
-evaluated against current **modulecmd.tcl**'s mode which leads to specific
+evaluated against current :file:`modulecmd.tcl`'s mode which leads to specific
 evaluation results. For instance if the *modulefile* sets a value to an
 environment variable, this variable is set when modulefile is loaded and unset
 when modulefile is unloaded.
@@ -320,8 +320,8 @@ the *modulefile* is being loaded.
 
 **module-info** option [info-args]
 
- Provide information about the **modulecmd.tcl** program's state. Some of the
- information is specific to the internals of **modulecmd.tcl**. *option*
+ Provide information about the :file:`modulecmd.tcl` program's state. Some of the
+ information is specific to the internals of :file:`modulecmd.tcl`. *option*
  is the type of information to be provided, and *info-args* are any
  arguments needed.
 
@@ -333,18 +333,18 @@ the *modulefile* is being loaded.
 
  **module-info mode** [modetype]
 
-  Returns the current **modulecmd.tcl**'s mode as a string if no *modetype*
+  Returns the current :file:`modulecmd.tcl`'s mode as a string if no *modetype*
   is given.
 
-  Returns 1 if **modulecmd.tcl**'s mode is *modetype*. *modetype* can be:
+  Returns 1 if :file:`modulecmd.tcl`'s mode is *modetype*. *modetype* can be:
   load, unload, remove, switch, display, help, test or whatis.
 
  **module-info command** [commandname]
 
-  Returns the currently running **modulecmd.tcl**'s command as a string
+  Returns the currently running :file:`modulecmd.tcl`'s command as a string
   if no *commandname* is given.
 
-  Returns 1 if **modulecmd.tcl**'s command is *commandname*. *commandname*
+  Returns 1 if :file:`modulecmd.tcl`'s command is *commandname*. *commandname*
   can be: load, unload, reload, source, switch, display, avail, aliases,
   list, whatis, search, purge, restore, help or test.
 
@@ -360,11 +360,11 @@ the *modulefile* is being loaded.
 
  **module-info shell** [shellname]
 
-  Return the current shell under which **modulecmd.tcl** was invoked if
+  Return the current shell under which :file:`modulecmd.tcl` was invoked if
   no *shellname* is given. The current shell is the first parameter of
-  **modulecmd.tcl**, which is normally hidden by the **module** alias.
+  :file:`modulecmd.tcl`, which is normally hidden by the **module** alias.
 
-  If a *shellname* is given, returns 1 if **modulecmd.tcl**'s current shell
+  If a *shellname* is given, returns 1 if :file:`modulecmd.tcl`'s current shell
   is *shellname*, returns 0 otherwise. *shellname* can be: sh, bash, ksh,
   zsh, csh, tcsh, fish, tcl, perl, python, ruby, lisp, cmake, r.
 
@@ -372,10 +372,10 @@ the *modulefile* is being loaded.
 
   Return the family of the shell under which *modulefile* was invoked if no
   *shelltypename* is given. As of **module-info shell** this depends on the
-  first parameter of **modulecmd.tcl**. The output reflects a shell type
-  determining the shell syntax of the commands produced by **modulecmd.tcl**.
+  first parameter of :file:`modulecmd.tcl`. The output reflects a shell type
+  determining the shell syntax of the commands produced by :file:`modulecmd.tcl`.
 
-  If a *shelltypename* is given, returns 1 if **modulecmd.tcl**'s current
+  If a *shelltypename* is given, returns 1 if :file:`modulecmd.tcl`'s current
   shell type is *shelltypename*, returns 0 otherwise. *shelltypename*
   can be: sh, csh, fish, tcl, perl, python, ruby, lisp, cmake, r.
 
@@ -411,12 +411,12 @@ the *modulefile* is being loaded.
 **module-version** modulefile version-name...
 
  Assigns the symbolic *version-name* to the *modulefile*. This command
- should be placed in one of the **modulecmd.tcl** rc files in order to
+ should be placed in one of the :file:`modulecmd.tcl` rc files in order to
  provide shorthand invocations of frequently used *modulefile* names.
 
  The special *version-name* default specifies the default version to be
  used for module commands, if no specific version is given. This replaces
- the definitions made in the *.version* file in former **modulecmd.tcl**
+ the definitions made in the :file:`.version` file in former :file:`modulecmd.tcl`
  releases.
 
  The parameter *modulefile* may be either
@@ -434,7 +434,7 @@ the *modulefile* is being loaded.
 **module-alias** name modulefile
 
  Assigns the *modulefile* to the alias *name*. This command should be
- placed in one of the **modulecmd.tcl** rc files in order to provide
+ placed in one of the :file:`modulecmd.tcl` rc files in order to provide
  shorthand invocations of frequently used *modulefile* names.
 
  The parameter *modulefile* may be either
@@ -466,7 +466,7 @@ the *modulefile* is being loaded.
  Defines a string which is displayed in case of the invocation of the
  **module whatis** command. There may be more than one **module-whatis**
  line in a *modulefile*. This command takes no actions in case of **load**,
- **display**, etc. invocations of **modulecmd.tcl**.
+ **display**, etc. invocations of :file:`modulecmd.tcl`.
 
  The *string* parameter has to be enclosed in double-quotes if there's more
  than one word specified. Words are defined to be separated by whitespace
@@ -508,7 +508,7 @@ the *modulefile* is being loaded.
 
  Run *string* command through shell. On Unix, command is passed to the
  ``/bin/sh`` shell whereas on Windows it is passed to ``cmd.exe``.
- **modulecmd.tcl** redirects stdout to stderr since stdout would be parsed by
+ :file:`modulecmd.tcl` redirects stdout to stderr since stdout would be parsed by
  the evaluating shell. The exit status of the executed command is returned.
 
 .. _uname:
@@ -583,21 +583,21 @@ Every directory in **MODULEPATH** is searched to find the
 *modulefile*. A directory in **MODULEPATH** can have an arbitrary number
 of sub-directories. If the user names a *modulefile* to be loaded which
 is actually a directory, the directory is opened and a search begins for
-an actual *modulefile*. First, **modulecmd.tcl** looks for a file with
-the name *.modulerc* in the directory. If this file exists, its contents
+an actual *modulefile*. First, :file:`modulecmd.tcl` looks for a file with
+the name :file:`.modulerc` in the directory. If this file exists, its contents
 will be evaluated as if it was a *modulefile* to be loaded. You may place
 **module-version**, **module-alias** and **module-virtual** commands inside
 this file.
 
-Additionally, before seeking for *.modulerc* files in the module directory,
-the global modulerc file and the *.modulerc* file found at the root of the
+Additionally, before seeking for :file:`.modulerc` files in the module directory,
+the global modulerc file and the :file:`.modulerc` file found at the root of the
 modulepath directory are sourced, too. If a named version default now exists
 for the *modulefile* to be loaded, the assigned *modulefile* now will be
-sourced. Otherwise the file *.version* is looked up in the module directory.
+sourced. Otherwise the file :file:`.version` is looked up in the module directory.
 
-If the *.version* file exists, it is opened and interpreted as Tcl code and
-takes precedence over a *.modulerc* file in the same directory. If the Tcl
-variable **ModulesVersion** is set by the *.version* file, **modulecmd.tcl**
+If the :file:`.version` file exists, it is opened and interpreted as Tcl code and
+takes precedence over a :file:`.modulerc` file in the same directory. If the Tcl
+variable **ModulesVersion** is set by the :file:`.version` file, :file:`modulecmd.tcl`
 will use the name as if it specifies a *modulefile* in this directory. This
 will become the default *modulefile* in this case. **ModulesVersion** cannot
 refer to a *modulefile* located in a different directory.
@@ -607,9 +607,9 @@ directory. If the name does not match any files located in the current
 directory, the search continues through the remaining directories in
 **MODULEPATH**.
 
-Every *.version* and *.modulerc* file found is interpreted as Tcl code. The
-difference is that *.version* only applies to the current directory, and the
-*.modulerc* applies to the current directory and all subdirectories. Changes
+Every :file:`.version` and :file:`.modulerc` file found is interpreted as Tcl code. The
+difference is that :file:`.version` only applies to the current directory, and the
+:file:`.modulerc` applies to the current directory and all subdirectories. Changes
 made in these files will affect the subsequently interpreted *modulefile*.
 
 If no default version may be figured out, an implicit default is selected when
@@ -623,7 +623,7 @@ achieve this sort. If highest numerically sorted element is an alias, search
 continues on its *modulefile* target.
 
 For example, it is possible for a user to have a directory named X11 which
-simply contains a *.version* file specifying which version of X11 is to
+simply contains a :file:`.version` file specifying which version of X11 is to
 be loaded. Such a file would look like:
 
 .. code-block:: tcl
@@ -634,7 +634,7 @@ be loaded. Such a file would look like:
      ##
      set ModulesVersion "R4"
 
-The equivalent *.modulerc* would look like:
+The equivalent :file:`.modulerc` would look like:
 
 .. code-block:: tcl
 
@@ -657,7 +657,7 @@ first looking at the *modulefiles* in the *modulepath* where this alias or
 symbol is defined. If not found, resolution looks at the other *modulepaths*
 in their definition order.
 
-When locating *modulefiles*, if a *.modulerc*, a *.version*, a directory
+When locating *modulefiles*, if a :file:`.modulerc`, a :file:`.version`, a directory
 or a *modulefile* cannot be read during the search it is simply ignored
 with no error message produced. Visibility of *modulefiles* can thus be
 adapted to the rights the user has been granted. Exception is made when
@@ -734,7 +734,7 @@ Modulefile Display
 
 The **module display modulefile** command will detail all changes that
 will be made to the environment. After displaying all of the environment
-changes **modulecmd.tcl** will call the **ModulesDisplay** subroutine. The
+changes :file:`modulecmd.tcl` will call the **ModulesDisplay** subroutine. The
 **ModulesDisplay** subroutine is a good place to put additional descriptive
 information about the *modulefile*.
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -249,12 +249,20 @@ the *modulefile* is being loaded.
  *collection* argument is provided, a true value will only be returned if
  a collection matching currently set target exists.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. mfcmd:: is-used [directory...]
 
  The :mfcmd:`is-used` command returns a true value if any of the listed
  *directories* has been enabled in :envvar:`MODULEPATH` or if any *directory* is
  enabled in case no argument is provided. If a list contains more than one
  *directory*, then each member acts as a boolean OR operation.
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. mfcmd:: is-avail modulefile...
 
@@ -267,6 +275,10 @@ the *modulefile* is being loaded.
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
+
+ .. only:: html
+
+    .. versionadded:: 4.1
 
 .. mfcmd:: module [sub-command] [sub-command-args]
 
@@ -311,6 +323,10 @@ the *modulefile* is being loaded.
   Returns ``1`` if :file:`modulecmd.tcl`'s command is *commandname*. *commandname*
   can be: ``load``, ``unload``, ``reload``, ``source``, ``switch``, ``display``, ``avail``, ``aliases``,
   ``list``, ``whatis``, ``search``, ``purge``, ``restore``, ``help`` or ``test``.
+
+  .. only:: html
+
+     .. versionadded:: 4.0
 
  **module-info name**
 
@@ -370,6 +386,10 @@ the *modulefile* is being loaded.
   *modulefiles* from the directory will be returned. The parameter
   *modulefile* may also be a symbolic modulefile name or a modulefile alias.
 
+  .. only:: html
+
+     .. versionadded:: 4.1
+
 .. mfcmd:: module-version modulefile version-name...
 
  Assigns the symbolic *version-name* to the *modulefile*. This command
@@ -417,6 +437,10 @@ the *modulefile* is being loaded.
  The parameter *modulefile* corresponds to the relative or absolute file
  location of a *modulefile*.
 
+ .. only:: html
+
+    .. versionadded:: 4.1
+
 .. mfcmd:: module-whatis string
 
  Defines a string which is displayed in case of the invocation of the
@@ -446,9 +470,17 @@ the *modulefile* is being loaded.
  possible and the command has no effect. When a *modulefile* is unloaded,
  :mfcmd:`set-function` becomes :mfcmd:`unset-function`.
 
+ .. only:: html
+
+    .. versionadded:: 4.2
+
 .. mfcmd:: unset-function function-name
 
  Removes a function with the name *function-name* from the user's environment.
+
+ .. only:: html
+
+    .. versionadded:: 4.2
 
 .. mfcmd:: system string
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -742,7 +742,7 @@ information about the *modulefile*.
 ENVIRONMENT
 -----------
 
-**MODULEPATH**
+.. envvar:: MODULEPATH
 
  Path of directories containing *modulefiles*.
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -65,11 +65,11 @@ the *modulefile* is being loaded.
 .. mfcmd:: break
 
  This is not a Modules-specific command, it's actually part of Tcl, which
- has been overloaded similar to the **continue** and **exit** commands
+ has been overloaded similar to the :mfcmd:`continue` and :mfcmd:`exit` commands
  to have the effect of causing the module not to be listed as loaded and
  not affect other modules being loaded concurrently. All non-environment
  commands within the module will be performed up to this point and processing
- will continue on to the next module on the command line. The **break**
+ will continue on to the next module on the command line. The :mfcmd:`break`
  command will only have this effect if not used within a Tcl loop though.
 
  An example: Suppose that a full selection of *modulefiles* are needed for
@@ -102,16 +102,16 @@ the *modulefile* is being loaded.
 .. mfcmd:: continue
 
  This is not a modules specific command but another overloaded Tcl command
- and is similar to the **break** or **exit** commands except the module
+ and is similar to the :mfcmd:`break` or :mfcmd:`exit` commands except the module
  will be listed as loaded as well as performing any environment or Tcl
  commands up to this point and then continuing on to the next module on
- the command line. The **continue** command will only have this effect if
+ the command line. The :mfcmd:`continue` command will only have this effect if
  not used within a Tcl loop though.
 
 .. mfcmd:: exit [N]
 
  This is not a modules specific command but another overloaded Tcl command
- and is similar to the **break** or **continue** commands. However,
+ and is similar to the :mfcmd:`break` or :mfcmd:`continue` commands. However,
  this command will cause the immediate cessation of this module and any
  additional ones on the command line. This module and the subsequent
  modules will not be listed as loaded. No environment commands will be
@@ -119,16 +119,16 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: setenv variable value
 
- Set environment *variable* to *value*. The **setenv** command will also
+ Set environment *variable* to *value*. The :mfcmd:`setenv` command will also
  change the process' environment. A reference using Tcl's env associative
- array will reference changes made with the **setenv** command. Changes
+ array will reference changes made with the :mfcmd:`setenv` command. Changes
  made using Tcl's *env* associative array will **NOT** change the user's
- environment *variable* like the **setenv** command. An environment change
- made this way will only affect the module parsing process. The **setenv**
+ environment *variable* like the :mfcmd:`setenv` command. An environment change
+ made this way will only affect the module parsing process. The :mfcmd:`setenv`
  command is also useful for changing the environment prior to the **exec**
- or **system** command. When a *modulefile* is unloaded, **setenv** becomes
- **unsetenv**. If the environment *variable* had been defined it will
- be overwritten while loading the *modulefile*. A subsequent **unload**
+ or :mfcmd:`system` command. When a *modulefile* is unloaded, :mfcmd:`setenv` becomes
+ :mfcmd:`unsetenv`. If the environment *variable* had been defined it will
+ be overwritten while loading the *modulefile*. A subsequent :subcmd:`unload`
  will unset the environment *variable* - the previous value cannot be
  restored! (Unless you handle it explicitly ... see below.)
 
@@ -136,18 +136,18 @@ the *modulefile* is being loaded.
 
  Unsets environment *variable*. However, if there is an optional *value*,
  then when unloading a module, it will set *variable* to *value*. The
- **unsetenv** command changes the process' environment like **setenv**.
+ :mfcmd:`unsetenv` command changes the process' environment like :mfcmd:`setenv`.
 
 .. mfcmd:: getenv variable [value]
 
  Returns value of environment *variable*. If *variable* is not defined *value*
- is returned if set *_UNDEFINED_* is returned otherwise. **getenv** command
+ is returned if set *_UNDEFINED_* is returned otherwise. :mfcmd:`getenv` command
  should be preferred over Tcl global variable **env** to query environment
  variables.
 
 .. mfcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
- See **prepend-path**.
+ See :mfcmd:`prepend-path`.
 
 .. mfcmd:: prepend-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
@@ -168,7 +168,7 @@ the *modulefile* is being loaded.
  again except if ``--duplicates`` option is set.
 
  If the *variable* is not set, it is created. When a *modulefile* is
- unloaded, **append-path** and **prepend-path** become **remove-path**.
+ unloaded, :mfcmd:`append-path` and :mfcmd:`prepend-path` become :mfcmd:`remove-path`.
 
  If *value* corresponds to the concatenation of multiple elements separated by
  colon, or *delimiter*, character, each element is treated separately.
@@ -176,7 +176,7 @@ the *modulefile* is being loaded.
 .. mfcmd:: remove-path [-d C|--delim C|--delim=C] [--index] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in
- *variable*. See **prepend-path** or **append-path** for further explanation
+ *variable*. See :mfcmd:`prepend-path` or :mfcmd:`append-path` for further explanation
  of using an arbitrary delimiter. Every string between colons, or delimiters,
  in *variable* is compared to *value*. If the two match, *value* is removed
  from *variable* if its reference counter is equal to 1 or unknown.
@@ -196,28 +196,28 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: prereq modulefile...
 
- See **conflict**.
+ See :mfcmd:`conflict`.
 
 .. mfcmd:: conflict modulefile...
 
- **prereq** and **conflict** control whether or not the *modulefile* will
- be loaded. The **prereq** command lists *modulefiles* which must have been
+ :mfcmd:`prereq` and :mfcmd:`conflict` control whether or not the *modulefile* will
+ be loaded. The :mfcmd:`prereq` command lists *modulefiles* which must have been
  previously loaded before the current *modulefile* will be loaded. Similarly,
- the **conflict** command lists *modulefiles* which **conflict** with the
+ the :mfcmd:`conflict` command lists *modulefiles* which :mfcmd:`conflict` with the
  current *modulefile*. If a list contains more than one *modulefile*, then
- each member of the list acts as a Boolean OR operation. Multiple **prereq**
- and **conflict** commands may be used to create a Boolean AND operation. If
+ each member of the list acts as a Boolean OR operation. Multiple :mfcmd:`prereq`
+ and :mfcmd:`conflict` commands may be used to create a Boolean AND operation. If
  one of the requirements have not been satisfied, an error is reported
  and the current *modulefile* makes no changes to the user's environment.
 
- If an argument for **prereq** is a directory and any *modulefile* from
+ If an argument for :mfcmd:`prereq` is a directory and any *modulefile* from
  the directory has been loaded, then the prerequisite is met. For example,
- specifying X11 as a **prereq** means that any version of X11, X11/R4 or
+ specifying X11 as a :mfcmd:`prereq` means that any version of X11, X11/R4 or
  X11/R5, must be loaded before proceeding.
 
- If an argument for **conflict** is a directory and any other *modulefile*
+ If an argument for :mfcmd:`conflict` is a directory and any other *modulefile*
  from that directory has been loaded, then a conflict will occur. For
- example, specifying X11 as a **conflict** will stop X11/R4 and X11/R5
+ example, specifying X11 as a :mfcmd:`conflict` will stop X11/R4 and X11/R5
  from being loaded at the same time.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -226,12 +226,12 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: is-loaded [modulefile...]
 
- The **is-loaded** command returns a true value if any of the listed
+ The :mfcmd:`is-loaded` command returns a true value if any of the listed
  *modulefiles* has been loaded or if any *modulefile* is loaded in case no
  argument is provided. If a list contains more than one *modulefile*, then
- each member acts as a boolean OR operation. If an argument for **is-loaded**
+ each member acts as a boolean OR operation. If an argument for :mfcmd:`is-loaded`
  is a directory and any *modulefile* from the directory has been loaded
- **is-loaded** would return a true value.
+ :mfcmd:`is-loaded` would return a true value.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -239,7 +239,7 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: is-saved [collection...]
 
- The **is-saved** command returns a true value if any of the listed
+ The :mfcmd:`is-saved` command returns a true value if any of the listed
  *collections* exists or if any *collection* exists in case no argument is
  provided. If a list contains more than one *collection*, then each member
  acts as a boolean OR operation.
@@ -251,18 +251,18 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: is-used [directory...]
 
- The **is-used** command returns a true value if any of the listed
+ The :mfcmd:`is-used` command returns a true value if any of the listed
  *directories* has been enabled in :envvar:`MODULEPATH` or if any *directory* is
  enabled in case no argument is provided. If a list contains more than one
  *directory*, then each member acts as a boolean OR operation.
 
 .. mfcmd:: is-avail modulefile...
 
- The **is-avail** command returns a true value if any of the listed
+ The :mfcmd:`is-avail` command returns a true value if any of the listed
  *modulefiles* exists in enabled :envvar:`MODULEPATH`. If a list contains more than
  one *modulefile*, then each member acts as a boolean OR operation. If an
- argument for **is-avail** is a directory and a *modulefile* exists in the
- directory **is-avail** would return a true value.
+ argument for :mfcmd:`is-avail` is a directory and a *modulefile* exists in the
+ directory :mfcmd:`is-avail` would return a true value.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -280,7 +280,7 @@ the *modulefile* is being loaded.
  would contain the necessary ``module load`` commands.
 
  Command line switches :option:`--auto`, :option:`--no-auto` and :option:`--force` are ignored
- when passed to a **module** command set in a *modulefile*.
+ when passed to a :mfcmd:`module` command set in a *modulefile*.
 
 .. mfcmd:: module-info option [info-args]
 
@@ -335,7 +335,7 @@ the *modulefile* is being loaded.
  **module-info shelltype** [shelltypename]
 
   Return the family of the shell under which *modulefile* was invoked if no
-  *shelltypename* is given. As of **module-info shell** this depends on the
+  *shelltypename* is given. As of :mfcmd:`module-info shell` this depends on the
   first parameter of :file:`modulecmd.tcl`. The output reflects a shell type
   determining the shell syntax of the commands produced by :file:`modulecmd.tcl`.
 
@@ -420,7 +420,7 @@ the *modulefile* is being loaded.
 .. mfcmd:: module-whatis string
 
  Defines a string which is displayed in case of the invocation of the
- :subcmd:`module whatis<whatis>` command. There may be more than one **module-whatis**
+ :subcmd:`module whatis<whatis>` command. There may be more than one :mfcmd:`module-whatis`
  line in a *modulefile*. This command takes no actions in case of :subcmd:`load`,
  :subcmd:`display`, etc. invocations of :file:`modulecmd.tcl`.
 
@@ -433,7 +433,7 @@ the *modulefile* is being loaded.
  Sets an alias or function with the name *alias-name* in the user's
  environment to the string *alias-string*. For some shells, aliases are not
  possible and the command has no effect. When a *modulefile* is unloaded,
- **set-alias** becomes **unset-alias**.
+ :mfcmd:`set-alias` becomes :mfcmd:`unset-alias`.
 
 .. mfcmd:: unset-alias alias-name
 
@@ -444,7 +444,7 @@ the *modulefile* is being loaded.
  Creates a function with the name *function-name* in the user's environment
  with the function body *function-string*. For some shells, functions are not
  possible and the command has no effect. When a *modulefile* is unloaded,
- **set-function** becomes **unset-function**.
+ :mfcmd:`set-function` becomes :mfcmd:`unset-function`.
 
 .. mfcmd:: unset-function function-name
 
@@ -463,7 +463,7 @@ the *modulefile* is being loaded.
  from the **tcl_platform** array (see :manpage:`tclvars(n)` man page). Uname will
  return the string "unknown" if information is unavailable for the *field*.
 
- **uname** will invoke :manpage:`uname(1)` command in order to get the operating
+ :mfcmd:`uname` will invoke :manpage:`uname(1)` command in order to get the operating
  system version and :manpage:`domainname(1)` to figure out the name of the domain.
 
  *field* values are:
@@ -489,9 +489,9 @@ the *modulefile* is being loaded.
  or *resource-string* is then passed down to be :manpage:`xrdb(1)` command.
 
  *modulefiles* that use this command, should in most cases contain one or
- more **x-resource** lines, each defining one X11 resource. The :envvar:`DISPLAY`
+ more :mfcmd:`x-resource` lines, each defining one X11 resource. The :envvar:`DISPLAY`
  environment variable should be properly set and the X11 server should be
- accessible. If **x-resource** can't manipulate the X11 resource database,
+ accessible. If :mfcmd:`x-resource` can't manipulate the X11 resource database,
  the *modulefile* will exit with an error message.
 
  Examples:
@@ -528,7 +528,7 @@ is actually a directory, the directory is opened and a search begins for
 an actual *modulefile*. First, :file:`modulecmd.tcl` looks for a file with
 the name :file:`.modulerc` in the directory. If this file exists, its contents
 will be evaluated as if it was a *modulefile* to be loaded. You may place
-**module-version**, **module-alias** and **module-virtual** commands inside
+:mfcmd:`module-version`, :mfcmd:`module-alias` and :mfcmd:`module-virtual` commands inside
 this file.
 
 Additionally, before seeking for :file:`.modulerc` files in the module directory,

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -29,7 +29,7 @@ has been configured for your installation of the Modules package, you may
 use all the extended commands provided by tclX, too.
 
 A typical *modulefile* is a simple bit of code that set or add entries
-to the **PATH**, **MANPATH**, or other environment variables. A Modulefile is
+to the :envvar:`PATH`, :envvar:`MANPATH`, or other environment variables. A Modulefile is
 evaluated against current :file:`modulecmd.tcl`'s mode which leads to specific
 evaluation results. For instance if the *modulefile* sets a value to an
 environment variable, this variable is set when modulefile is loaded and unset
@@ -272,7 +272,7 @@ the *modulefile* is being loaded.
  provided. If a list contains more than one *collection*, then each member
  acts as a boolean OR operation.
 
- If **MODULES_COLLECTION_TARGET** is set, a suffix equivalent to the value
+ If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
  of this variable is appended to the passed *collection* name. In case no
  *collection* argument is provided, a true value will only be returned if
  a collection matching currently set target exists.
@@ -282,7 +282,7 @@ the *modulefile* is being loaded.
 **is-used** [directory...]
 
  The **is-used** command returns a true value if any of the listed
- *directories* has been enabled in **MODULEPATH** or if any *directory* is
+ *directories* has been enabled in :envvar:`MODULEPATH` or if any *directory* is
  enabled in case no argument is provided. If a list contains more than one
  *directory*, then each member acts as a boolean OR operation.
 
@@ -291,7 +291,7 @@ the *modulefile* is being loaded.
 **is-avail** modulefile...
 
  The **is-avail** command returns a true value if any of the listed
- *modulefiles* exists in enabled **MODULEPATH**. If a list contains more than
+ *modulefiles* exists in enabled :envvar:`MODULEPATH`. If a list contains more than
  one *modulefile*, then each member acts as a boolean OR operation. If an
  argument for **is-avail** is a directory and a *modulefile* exists in the
  directory **is-avail** would return a true value.
@@ -547,7 +547,7 @@ the *modulefile* is being loaded.
  or *resource-string* is then passed down to be :manpage:`xrdb(1)` command.
 
  *modulefiles* that use this command, should in most cases contain one or
- more **x-resource** lines, each defining one X11 resource. The **DISPLAY**
+ more **x-resource** lines, each defining one X11 resource. The :envvar:`DISPLAY`
  environment variable should be properly set and the X11 server should be
  accessible. If **x-resource** can't manipulate the X11 resource database,
  the *modulefile* will exit with an error message.
@@ -579,8 +579,8 @@ the *modulefile* being interpreted.
 Locating Modulefiles
 --------------------
 
-Every directory in **MODULEPATH** is searched to find the
-*modulefile*. A directory in **MODULEPATH** can have an arbitrary number
+Every directory in :envvar:`MODULEPATH` is searched to find the
+*modulefile*. A directory in :envvar:`MODULEPATH` can have an arbitrary number
 of sub-directories. If the user names a *modulefile* to be loaded which
 is actually a directory, the directory is opened and a search begins for
 an actual *modulefile*. First, :file:`modulecmd.tcl` looks for a file with
@@ -605,7 +605,7 @@ refer to a *modulefile* located in a different directory.
 If **ModulesVersion** is a directory, the search begins anew down that
 directory. If the name does not match any files located in the current
 directory, the search continues through the remaining directories in
-**MODULEPATH**.
+:envvar:`MODULEPATH`.
 
 Every :file:`.version` and :file:`.modulerc` file found is interpreted as Tcl code. The
 difference is that :file:`.version` only applies to the current directory, and the
@@ -613,7 +613,7 @@ difference is that :file:`.version` only applies to the current directory, and t
 made in these files will affect the subsequently interpreted *modulefile*.
 
 If no default version may be figured out, an implicit default is selected when
-this behavior is enabled (see **MODULES_IMPLICIT_DEFAULT** in
+this behavior is enabled (see :envvar:`MODULES_IMPLICIT_DEFAULT` in
 :ref:`module(1)`). If disabled, module names should be fully qualified when no
 explicit default is defined for them, otherwise no default version is found
 and an error is returned. If enabled, then the highest numerically sorted
@@ -645,7 +645,7 @@ The equivalent :file:`.modulerc` would look like:
      module-version "./R4" default
 
 If the extended default mechanism is enabled (see
-**MODULES_EXTENDED_DEFAULT** in :ref:`module(1)`) the module version specified
+:envvar:`MODULES_EXTENDED_DEFAULT` in :ref:`module(1)`) the module version specified
 is matched against starting portion of existing module versions, where portion
 is a substring separated from the rest of version string by a ``.`` character.
 
@@ -676,7 +676,7 @@ Advanced module version specifiers
 ----------------------------------
 
 When the advanced module version specifiers mechanism is enabled (see
-**MODULES_ADVANCED_VERSION_SPEC** in :ref:`module(1)`), the specification of
+:envvar:`MODULES_ADVANCED_VERSION_SPEC` in :ref:`module(1)`), the specification of
 modulefile passed on Modules specific Tcl commands changes. After the module
 name a version constraint prefixed by the ``@`` character may be added. It
 could be directly appended to the module name or separated from it with a
@@ -697,7 +697,7 @@ Constraints can be expressed to refine the selection of module version to:
 
 Advanced specification of single version or list of versions may benefit from
 the activation of the extended default mechanism (see
-**MODULES_EXTENDED_DEFAULT** in :ref:`module(1)`) to use an abbreviated
+:envvar:`MODULES_EXTENDED_DEFAULT` in :ref:`module(1)`) to use an abbreviated
 notation like ``@1`` to refer to more precise version numbers like ``1.2.3``.
 Range of versions on its side natively handles abbreviated versions.
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -62,9 +62,7 @@ Module commands return the empty string. Some commands behave differently
 when a *modulefile* is loaded or unloaded. The command descriptions assume
 the *modulefile* is being loaded.
 
-.. _break:
-
-**break**
+.. mfcmd:: break
 
  This is not a Modules-specific command, it's actually part of Tcl, which
  has been overloaded similar to the **continue** and **exit** commands
@@ -97,15 +95,11 @@ the *modulefile* is being loaded.
       }
       break
 
-.. _chdir:
-
-**chdir** directory
+.. mfcmd:: chdir directory
 
  Set the current working directory to *directory*.
 
-.. _continue:
-
-**continue**
+.. mfcmd:: continue
 
  This is not a modules specific command but another overloaded Tcl command
  and is similar to the **break** or **exit** commands except the module
@@ -114,9 +108,7 @@ the *modulefile* is being loaded.
  the command line. The **continue** command will only have this effect if
  not used within a Tcl loop though.
 
-.. _exit:
-
-**exit** [N]
+.. mfcmd:: exit [N]
 
  This is not a modules specific command but another overloaded Tcl command
  and is similar to the **break** or **continue** commands. However,
@@ -125,9 +117,7 @@ the *modulefile* is being loaded.
  modules will not be listed as loaded. No environment commands will be
  performed in the current module.
 
-.. _setenv:
-
-**setenv** variable value
+.. mfcmd:: setenv variable value
 
  Set environment *variable* to *value*. The **setenv** command will also
  change the process' environment. A reference using Tcl's env associative
@@ -142,32 +132,24 @@ the *modulefile* is being loaded.
  will unset the environment *variable* - the previous value cannot be
  restored! (Unless you handle it explicitly ... see below.)
 
-.. _unsetenv:
-
-**unsetenv** variable [value]
+.. mfcmd:: unsetenv variable [value]
 
  Unsets environment *variable*. However, if there is an optional *value*,
  then when unloading a module, it will set *variable* to *value*. The
  **unsetenv** command changes the process' environment like **setenv**.
 
-.. _getenv:
-
-**getenv** variable [value]
+.. mfcmd:: getenv variable [value]
 
  Returns value of environment *variable*. If *variable* is not defined *value*
  is returned if set *_UNDEFINED_* is returned otherwise. **getenv** command
  should be preferred over Tcl global variable **env** to query environment
  variables.
 
-.. _append-path:
-
-**append-path** [-d C|--delim C|--delim=C] [--duplicates] variable value...
+.. mfcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  See **prepend-path**.
 
-.. _prepend-path:
-
-**prepend-path** [-d C|--delim C|--delim=C] [--duplicates] variable value...
+.. mfcmd:: prepend-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
  Append or prepend *value* to environment *variable*. The
  *variable* is a colon, or *delimiter*, separated list such as
@@ -191,9 +173,7 @@ the *modulefile* is being loaded.
  If *value* corresponds to the concatenation of multiple elements separated by
  colon, or *delimiter*, character, each element is treated separately.
 
-.. _remove-path:
-
-**remove-path** [-d C|--delim C|--delim=C] [--index] variable value...
+.. mfcmd:: remove-path [-d C|--delim C|--delim=C] [--index] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in
  *variable*. See **prepend-path** or **append-path** for further explanation
@@ -214,15 +194,11 @@ the *modulefile* is being loaded.
  If *value* corresponds to the concatenation of multiple elements separated by
  colon, or *delimiter*, character, each element is treated separately.
 
-.. _prereq:
-
-**prereq** modulefile...
+.. mfcmd:: prereq modulefile...
 
  See **conflict**.
 
-.. _conflict:
-
-**conflict** modulefile...
+.. mfcmd:: conflict modulefile...
 
  **prereq** and **conflict** control whether or not the *modulefile* will
  be loaded. The **prereq** command lists *modulefiles* which must have been
@@ -248,9 +224,7 @@ the *modulefile* is being loaded.
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _is-loaded:
-
-**is-loaded** [modulefile...]
+.. mfcmd:: is-loaded [modulefile...]
 
  The **is-loaded** command returns a true value if any of the listed
  *modulefiles* has been loaded or if any *modulefile* is loaded in case no
@@ -263,9 +237,7 @@ the *modulefile* is being loaded.
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _is-saved:
-
-**is-saved** [collection...]
+.. mfcmd:: is-saved [collection...]
 
  The **is-saved** command returns a true value if any of the listed
  *collections* exists or if any *collection* exists in case no argument is
@@ -277,18 +249,14 @@ the *modulefile* is being loaded.
  *collection* argument is provided, a true value will only be returned if
  a collection matching currently set target exists.
 
-.. _is-used:
-
-**is-used** [directory...]
+.. mfcmd:: is-used [directory...]
 
  The **is-used** command returns a true value if any of the listed
  *directories* has been enabled in :envvar:`MODULEPATH` or if any *directory* is
  enabled in case no argument is provided. If a list contains more than one
  *directory*, then each member acts as a boolean OR operation.
 
-.. _is-avail:
-
-**is-avail** modulefile...
+.. mfcmd:: is-avail modulefile...
 
  The **is-avail** command returns a true value if any of the listed
  *modulefiles* exists in enabled :envvar:`MODULEPATH`. If a list contains more than
@@ -300,9 +268,7 @@ the *modulefile* is being loaded.
  modulefile alias. It may also leverage a specific syntax to finely select
  module version (see `Advanced module version specifiers`_ section below).
 
-.. _module:
-
-**module** [sub-command] [sub-command-args]
+.. mfcmd:: module [sub-command] [sub-command-args]
 
  Contains the same *sub-commands* as described in the :ref:`module(1)`
  man page in the Module Sub-Commands section. This command permits a
@@ -316,9 +282,7 @@ the *modulefile* is being loaded.
  Command line switches :option:`--auto`, :option:`--no-auto` and :option:`--force` are ignored
  when passed to a **module** command set in a *modulefile*.
 
-.. _module-info:
-
-**module-info** option [info-args]
+.. mfcmd:: module-info option [info-args]
 
  Provide information about the :file:`modulecmd.tcl` program's state. Some of the
  information is specific to the internals of :file:`modulecmd.tcl`. *option*
@@ -406,9 +370,7 @@ the *modulefile* is being loaded.
   *modulefiles* from the directory will be returned. The parameter
   *modulefile* may also be a symbolic modulefile name or a modulefile alias.
 
-.. _module-version:
-
-**module-version** modulefile version-name...
+.. mfcmd:: module-version modulefile version-name...
 
  Assigns the symbolic *version-name* to the *modulefile*. This command
  should be placed in one of the :file:`modulecmd.tcl` rc files in order to
@@ -429,9 +391,7 @@ the *modulefile* is being loaded.
 
  * another *modulefile* alias
 
-.. _module-alias:
-
-**module-alias** name modulefile
+.. mfcmd:: module-alias name modulefile
 
  Assigns the *modulefile* to the alias *name*. This command should be
  placed in one of the :file:`modulecmd.tcl` rc files in order to provide
@@ -445,9 +405,7 @@ the *modulefile* is being loaded.
 
  * another *modulefile* alias
 
-.. _module-virtual:
-
-**module-virtual** name modulefile
+.. mfcmd:: module-virtual name modulefile
 
  Assigns the *modulefile* to the virtual module *name*. This command should be
  placed in rc files in order to define virtual modules.
@@ -459,9 +417,7 @@ the *modulefile* is being loaded.
  The parameter *modulefile* corresponds to the relative or absolute file
  location of a *modulefile*.
 
-.. _module-whatis:
-
-**module-whatis** string
+.. mfcmd:: module-whatis string
 
  Defines a string which is displayed in case of the invocation of the
  :subcmd:`module whatis<whatis>` command. There may be more than one **module-whatis**
@@ -472,48 +428,36 @@ the *modulefile* is being loaded.
  than one word specified. Words are defined to be separated by whitespace
  characters (space, tab, cr).
 
-.. _set-alias:
-
-**set-alias** alias-name alias-string
+.. mfcmd:: set-alias alias-name alias-string
 
  Sets an alias or function with the name *alias-name* in the user's
  environment to the string *alias-string*. For some shells, aliases are not
  possible and the command has no effect. When a *modulefile* is unloaded,
  **set-alias** becomes **unset-alias**.
 
-.. _unset-alias:
-
-**unset-alias** alias-name
+.. mfcmd:: unset-alias alias-name
 
  Unsets an alias with the name *alias-name* in the user's environment.
 
-.. _set-function:
-
-**set-function** function-name function-string
+.. mfcmd:: set-function function-name function-string
 
  Creates a function with the name *function-name* in the user's environment
  with the function body *function-string*. For some shells, functions are not
  possible and the command has no effect. When a *modulefile* is unloaded,
  **set-function** becomes **unset-function**.
 
-.. _unset-function:
-
-**unset-function** function-name
+.. mfcmd:: unset-function function-name
 
  Removes a function with the name *function-name* from the user's environment.
 
-.. _system:
-
-**system** string
+.. mfcmd:: system string
 
  Run *string* command through shell. On Unix, command is passed to the
  ``/bin/sh`` shell whereas on Windows it is passed to ``cmd.exe``.
  :file:`modulecmd.tcl` redirects stdout to stderr since stdout would be parsed by
  the evaluating shell. The exit status of the executed command is returned.
 
-.. _uname:
-
-**uname** field
+.. mfcmd:: uname field
 
  Provide lookup of system information. Most *field* information are retrieved
  from the **tcl_platform** array (see :manpage:`tclvars(n)` man page). Uname will
@@ -536,9 +480,7 @@ the *modulefile* is being loaded.
 
  * machine: a standard name that identifies the system's hardware
 
-.. _x-resource:
-
-**x-resource** [resource-string|filename]
+.. mfcmd:: x-resource [resource-string|filename]
 
  Merge resources into the X11 resource database. The resources are used to
  control look and behavior of X11 applications. The command will attempt

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -155,7 +155,7 @@ the *modulefile* is being loaded.
 **getenv** variable [value]
 
  Returns value of environment *variable*. If *variable* is not defined *value*
- is returned if set *_UNDEFINED_* is returned elsewhere. **getenv** command
+ is returned if set *_UNDEFINED_* is returned otherwise. **getenv** command
  should be preferred over Tcl global variable **env** to query environment
  variables.
 
@@ -208,7 +208,7 @@ the *modulefile* is being loaded.
  *value* has been added to *variable*. This information is stored in
  environment *variable_modshare*. When attempting to remove *value* from
  *variable*, relative reference counter is checked and *value* is removed
- only if counter is equal to 1 or not defined. Elsewhere *value* is kept
+ only if counter is equal to 1 or not defined. Otherwise *value* is kept
  in *variable* and reference counter is decreased by 1.
 
  If *value* corresponds to the concatenation of multiple elements separated by
@@ -365,7 +365,7 @@ the *modulefile* is being loaded.
   **modulecmd.tcl**, which is normally hidden by the **module** alias.
 
   If a *shellname* is given, returns 1 if **modulecmd.tcl**'s current shell
-  is *shellname*, returns 0 elsewhere. *shellname* can be: sh, bash, ksh,
+  is *shellname*, returns 0 otherwise. *shellname* can be: sh, bash, ksh,
   zsh, csh, tcsh, fish, tcl, perl, python, ruby, lisp, cmake, r.
 
  **module-info shelltype** [shelltypename]
@@ -376,7 +376,7 @@ the *modulefile* is being loaded.
   determining the shell syntax of the commands produced by **modulecmd.tcl**.
 
   If a *shelltypename* is given, returns 1 if **modulecmd.tcl**'s current
-  shell type is *shelltypename*, returns 0 elsewhere. *shelltypename*
+  shell type is *shelltypename*, returns 0 otherwise. *shelltypename*
   can be: sh, csh, fish, tcl, perl, python, ruby, lisp, cmake, r.
 
  **module-info alias** name
@@ -422,7 +422,7 @@ the *modulefile* is being loaded.
  The parameter *modulefile* may be either
 
  * a fully or partially qualified *modulefile* with name / version. If
-   name is '.' then the current directory name is assumed to be the module
+   name is ``.`` (dot) then the current directory name is assumed to be the module
    name. (Use this for deep *modulefile* directories.)
 
  * a symbolic *modulefile* name
@@ -606,7 +606,7 @@ directory. If the name does not match any files located in the current
 directory, the search continues through the remaining directories in
 **MODULEPATH**.
 
-Every *.version* and *.modulerc* file found is Tcl interpreted. The
+Every *.version* and *.modulerc* file found is interpreted as Tcl code. The
 difference is that *.version* only applies to the current directory, and the
 *.modulerc* applies to the current directory and all subdirectories. Changes
 made in these files will affect the subsequently interpreted *modulefile*.
@@ -614,7 +614,7 @@ made in these files will affect the subsequently interpreted *modulefile*.
 If no default version may be figured out, an implicit default is selected when
 this behavior is enabled (see **MODULES_IMPLICIT_DEFAULT** in
 :ref:`module(1)`). If disabled, module names should be fully qualified when no
-explicit default is defined for them, elsewhere no default version is found
+explicit default is defined for them, otherwise no default version is found
 and an error is returned. If enabled, then the highest numerically sorted
 *modulefile*, virtual module or module alias under the directory will be used.
 The dictionary comparison method of the **lsort**\ (n) Tcl command is used to
@@ -663,7 +663,7 @@ adapted to the rights the user has been granted. Exception is made when
 trying to directly access a directory or a *modulefile*. In this case,
 the access issue is returned as an error message.
 
-A *modulefile* whose name or element in its name starts with a '.' dot is
+A *modulefile* whose name or element in its name starts with a ``.`` (dot) is
 considered hidden. Hidden *modulefile* is not displayed or taken into account
 except if it is explicitly named. By inheritance, a symbolic version-name
 assigned to a hidden *modulefile* is displayed or taken into account only

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -7,7 +7,7 @@ modulefile
 DESCRIPTION
 -----------
 
-*modulefiles* are written in the Tool Command Language, **Tcl**\ (n) and are
+*modulefiles* are written in the Tool Command Language, :manpage:`Tcl(n)` and are
 interpreted by the :file:`modulecmd.tcl` program via the :ref:`module(1)` user
 interface. *modulefiles* can be loaded, unloaded, or switched on-the-fly
 while the user is working; and can be used to implement site policies
@@ -57,7 +57,7 @@ Modules Specific Tcl Commands
 -----------------------------
 
 The Modules Package uses commands which are extensions to the "standard"
-Tool Command Language **Tcl**\ (n) package. Unless otherwise specified, the
+Tool Command Language :manpage:`Tcl(n)` package. Unless otherwise specified, the
 Module commands return the empty string. Some commands behave differently
 when a *modulefile* is loaded or unloaded. The command descriptions assume
 the *modulefile* is being loaded.
@@ -516,11 +516,11 @@ the *modulefile* is being loaded.
 **uname** field
 
  Provide lookup of system information. Most *field* information are retrieved
- from the **tcl_platform** array (see **tclvars**\ (n) man page). Uname will
+ from the **tcl_platform** array (see :manpage:`tclvars(n)` man page). Uname will
  return the string "unknown" if information is unavailable for the *field*.
 
- **uname** will invoke **uname**\ (1) command in order to get the operating
- system version and **domainname**\ (1) to figure out the name of the domain.
+ **uname** will invoke :manpage:`uname(1)` command in order to get the operating
+ system version and :manpage:`domainname(1)` to figure out the name of the domain.
 
  *field* values are:
 
@@ -544,7 +544,7 @@ the *modulefile* is being loaded.
  control look and behavior of X11 applications. The command will attempt
  to read resources from *filename*. If the argument isn't a valid file
  name, then string will be interpreted as a resource. Either *filename*
- or *resource-string* is then passed down to be **xrdb**\ (1) command.
+ or *resource-string* is then passed down to be :manpage:`xrdb(1)` command.
 
  *modulefiles* that use this command, should in most cases contain one or
  more **x-resource** lines, each defining one X11 resource. The **DISPLAY**
@@ -618,7 +618,7 @@ this behavior is enabled (see **MODULES_IMPLICIT_DEFAULT** in
 explicit default is defined for them, otherwise no default version is found
 and an error is returned. If enabled, then the highest numerically sorted
 *modulefile*, virtual module or module alias under the directory will be used.
-The dictionary comparison method of the **lsort**\ (n) Tcl command is used to
+The dictionary comparison method of the :manpage:`lsort(n)` Tcl command is used to
 achieve this sort. If highest numerically sorted element is an alias, search
 continues on its *modulefile* target.
 
@@ -750,8 +750,8 @@ ENVIRONMENT
 SEE ALSO
 --------
 
-:ref:`module(1)`, **Tcl**\ (n), **TclX**\ (n), **xrdb**\ (1), **exec**\
-(n), **uname**\ (1), **domainname**\ (1), **tclvars**\ (n), **lsort**\ (n)
+:ref:`module(1)`, :manpage:`Tcl(n)`, :manpage:`TclX(n)`, :manpage:`xrdb(1)`, :manpage:`exec(n)`,
+:manpage:`uname(1)`, :manpage:`domainname(1)`, :manpage:`tclvars(n)`, :manpage:`lsort(n)`
 
 
 NOTES

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -7,19 +7,19 @@ modulefile
 DESCRIPTION
 -----------
 
-*modulefiles* are written in the Tool Command Language, :manpage:`Tcl(n)` and are
-interpreted by the :file:`modulecmd.tcl` program via the :ref:`module(1)` user
-interface. *modulefiles* can be loaded, unloaded, or switched on-the-fly
+*modulefiles* are written in the Tool Command Language, :manpage:`Tcl(n)` and
+are interpreted by the :file:`modulecmd.tcl` program via the :ref:`module(1)`
+user interface. *modulefiles* can be loaded, unloaded, or switched on-the-fly
 while the user is working; and can be used to implement site policies
 regarding the access and use of applications.
 
-A *modulefile* begins with the magic cookie, ``#%Module``. A version number may
-be placed after this string. The version number is useful as the *modulefile*
-format may change thus it reflects the minimum version of :file:`modulecmd.tcl`
-required to interpret the modulefile. If a version number doesn't exist, then
-:file:`modulecmd.tcl` will assume the *modulefile* is compatible. Files without
-the magic cookie or with a version number greater than the current version of
-:file:`modulecmd.tcl` will not be interpreted.
+A *modulefile* begins with the magic cookie, ``#%Module``. A version number
+may be placed after this string. The version number is useful as the
+*modulefile* format may change thus it reflects the minimum version of
+:file:`modulecmd.tcl` required to interpret the modulefile. If a version
+number doesn't exist, then :file:`modulecmd.tcl` will assume the *modulefile*
+is compatible. Files without the magic cookie or with a version number greater
+than the current version of :file:`modulecmd.tcl` will not be interpreted.
 
 Each *modulefile* contains the changes to a user's environment needed to
 access an application. Tcl is a simple programming language which permits
@@ -29,11 +29,11 @@ has been configured for your installation of the Modules package, you may
 use all the extended commands provided by tclX, too.
 
 A typical *modulefile* is a simple bit of code that set or add entries
-to the :envvar:`PATH`, :envvar:`MANPATH`, or other environment variables. A Modulefile is
-evaluated against current :file:`modulecmd.tcl`'s mode which leads to specific
-evaluation results. For instance if the *modulefile* sets a value to an
-environment variable, this variable is set when modulefile is loaded and unset
-when modulefile is unloaded.
+to the :envvar:`PATH`, :envvar:`MANPATH`, or other environment variables. A
+Modulefile is evaluated against current :file:`modulecmd.tcl`'s mode which
+leads to specific evaluation results. For instance if the *modulefile* sets a
+value to an environment variable, this variable is set when modulefile is
+loaded and unset when modulefile is unloaded.
 
 Tcl has conditional statements that are evaluated when the *modulefile* is
 interpreted. This is very effective for managing path or environment changes
@@ -57,17 +57,17 @@ Modules Specific Tcl Commands
 -----------------------------
 
 The Modules Package uses commands which are extensions to the "standard"
-Tool Command Language :manpage:`Tcl(n)` package. Unless otherwise specified, the
-Module commands return the empty string. Some commands behave differently
+Tool Command Language :manpage:`Tcl(n)` package. Unless otherwise specified,
+the Module commands return the empty string. Some commands behave differently
 when a *modulefile* is loaded or unloaded. The command descriptions assume
 the *modulefile* is being loaded.
 
 .. mfcmd:: break
 
  This is not a Modules-specific command, it's actually part of Tcl, which
- has been overloaded similar to the :mfcmd:`continue` and :mfcmd:`exit` commands
- to have the effect of causing the module not to be listed as loaded and
- not affect other modules being loaded concurrently. All non-environment
+ has been overloaded similar to the :mfcmd:`continue` and :mfcmd:`exit`
+ commands to have the effect of causing the module not to be listed as loaded
+ and not affect other modules being loaded concurrently. All non-environment
  commands within the module will be performed up to this point and processing
  will continue on to the next module on the command line. The :mfcmd:`break`
  command will only have this effect if not used within a Tcl loop though.
@@ -102,8 +102,8 @@ the *modulefile* is being loaded.
 .. mfcmd:: continue
 
  This is not a modules specific command but another overloaded Tcl command
- and is similar to the :mfcmd:`break` or :mfcmd:`exit` commands except the module
- will be listed as loaded as well as performing any environment or Tcl
+ and is similar to the :mfcmd:`break` or :mfcmd:`exit` commands except the
+ module will be listed as loaded as well as performing any environment or Tcl
  commands up to this point and then continuing on to the next module on
  the command line. The :mfcmd:`continue` command will only have this effect if
  not used within a Tcl loop though.
@@ -123,27 +123,29 @@ the *modulefile* is being loaded.
  change the process' environment. A reference using Tcl's env associative
  array will reference changes made with the :mfcmd:`setenv` command. Changes
  made using Tcl's ``env`` associative array will **NOT** change the user's
- environment *variable* like the :mfcmd:`setenv` command. An environment change
- made this way will only affect the module parsing process. The :mfcmd:`setenv`
- command is also useful for changing the environment prior to the ``exec``
- or :mfcmd:`system` command. When a *modulefile* is unloaded, :mfcmd:`setenv` becomes
- :mfcmd:`unsetenv`. If the environment *variable* had been defined it will
- be overwritten while loading the *modulefile*. A subsequent :subcmd:`unload`
- will unset the environment *variable* - the previous value cannot be
- restored! (Unless you handle it explicitly ... see below.)
+ environment *variable* like the :mfcmd:`setenv` command. An environment
+ change made this way will only affect the module parsing process. The
+ :mfcmd:`setenv` command is also useful for changing the environment prior to
+ the ``exec`` or :mfcmd:`system` command. When a *modulefile* is unloaded,
+ :mfcmd:`setenv` becomes :mfcmd:`unsetenv`. If the environment *variable* had
+ been defined it will be overwritten while loading the *modulefile*. A
+ subsequent :subcmd:`unload` will unset the environment *variable* - the
+ previous value cannot be restored! (Unless you handle it explicitly ... see
+ below.)
 
 .. mfcmd:: unsetenv variable [value]
 
  Unsets environment *variable*. However, if there is an optional *value*,
  then when unloading a module, it will set *variable* to *value*. The
- :mfcmd:`unsetenv` command changes the process' environment like :mfcmd:`setenv`.
+ :mfcmd:`unsetenv` command changes the process' environment like
+ :mfcmd:`setenv`.
 
 .. mfcmd:: getenv variable [value]
 
- Returns value of environment *variable*. If *variable* is not defined, *value*
- is returned if set, ``_UNDEFINED_`` is returned otherwise. The :mfcmd:`getenv` command
- should be preferred over the Tcl global variable ``env`` to query environment
- variables.
+ Returns value of environment *variable*. If *variable* is not defined,
+ *value* is returned if set, ``_UNDEFINED_`` is returned otherwise. The
+ :mfcmd:`getenv` command should be preferred over the Tcl global variable
+ ``env`` to query environment variables.
 
 .. mfcmd:: append-path [-d C|--delim C|--delim=C] [--duplicates] variable value...
 
@@ -168,7 +170,8 @@ the *modulefile* is being loaded.
  again except if ``--duplicates`` option is set.
 
  If the *variable* is not set, it is created. When a *modulefile* is
- unloaded, :mfcmd:`append-path` and :mfcmd:`prepend-path` become :mfcmd:`remove-path`.
+ unloaded, :mfcmd:`append-path` and :mfcmd:`prepend-path` become
+ :mfcmd:`remove-path`.
 
  If *value* corresponds to the concatenation of multiple elements separated by
  colon, or *delimiter*, character, each element is treated separately.
@@ -176,13 +179,13 @@ the *modulefile* is being loaded.
 .. mfcmd:: remove-path [-d C|--delim C|--delim=C] [--index] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in
- *variable*. See :mfcmd:`prepend-path` or :mfcmd:`append-path` for further explanation
- of using an arbitrary delimiter. Every string between colons, or delimiters,
- in *variable* is compared to *value*. If the two match, *value* is removed
- from *variable* if its reference counter is equal to 1 or unknown.
+ *variable*. See :mfcmd:`prepend-path` or :mfcmd:`append-path` for further
+ explanation of using an arbitrary delimiter. Every string between colons, or
+ delimiters, in *variable* is compared to *value*. If the two match, *value*
+ is removed from *variable* if its reference counter is equal to 1 or unknown.
 
- When ``--index`` option is set, *value* refers to an index in *variable* list.
- The string element pointed by this index is set for removal.
+ When ``--index`` option is set, *value* refers to an index in *variable*
+ list. The string element pointed by this index is set for removal.
 
  Reference counter of *value* in *variable* denotes the number of times
  *value* has been added to *variable*. This information is stored in
@@ -200,25 +203,26 @@ the *modulefile* is being loaded.
 
 .. mfcmd:: conflict modulefile...
 
- :mfcmd:`prereq` and :mfcmd:`conflict` control whether or not the *modulefile* will
- be loaded. The :mfcmd:`prereq` command lists *modulefiles* which must have been
- previously loaded before the current *modulefile* will be loaded. Similarly,
- the :mfcmd:`conflict` command lists *modulefiles* which :mfcmd:`conflict` with the
- current *modulefile*. If a list contains more than one *modulefile*, then
- each member of the list acts as a Boolean OR operation. Multiple :mfcmd:`prereq`
- and :mfcmd:`conflict` commands may be used to create a Boolean AND operation. If
- one of the requirements have not been satisfied, an error is reported
- and the current *modulefile* makes no changes to the user's environment.
+ :mfcmd:`prereq` and :mfcmd:`conflict` control whether or not the *modulefile*
+ will be loaded. The :mfcmd:`prereq` command lists *modulefiles* which must
+ have been previously loaded before the current *modulefile* will be loaded.
+ Similarly, the :mfcmd:`conflict` command lists *modulefiles* which
+ :mfcmd:`conflict` with the current *modulefile*. If a list contains more than
+ one *modulefile*, then each member of the list acts as a Boolean OR
+ operation. Multiple :mfcmd:`prereq` and :mfcmd:`conflict` commands may be
+ used to create a Boolean AND operation. If one of the requirements have not
+ been satisfied, an error is reported and the current *modulefile* makes no
+ changes to the user's environment.
 
  If an argument for :mfcmd:`prereq` is a directory and any *modulefile* from
  the directory has been loaded, then the prerequisite is met. For example,
  specifying X11 as a :mfcmd:`prereq` means that any version of X11, X11/R4 or
  X11/R5, must be loaded before proceeding.
 
- If an argument for :mfcmd:`conflict` is a directory and any other *modulefile*
- from that directory has been loaded, then a conflict will occur. For
- example, specifying X11 as a :mfcmd:`conflict` will stop X11/R4 and X11/R5
- from being loaded at the same time.
+ If an argument for :mfcmd:`conflict` is a directory and any other
+ *modulefile* from that directory has been loaded, then a conflict will occur.
+ For example, specifying X11 as a :mfcmd:`conflict` will stop X11/R4 and
+ X11/R5 from being loaded at the same time.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -229,9 +233,9 @@ the *modulefile* is being loaded.
  The :mfcmd:`is-loaded` command returns a true value if any of the listed
  *modulefiles* has been loaded or if any *modulefile* is loaded in case no
  argument is provided. If a list contains more than one *modulefile*, then
- each member acts as a boolean OR operation. If an argument for :mfcmd:`is-loaded`
- is a directory and any *modulefile* from the directory has been loaded
- :mfcmd:`is-loaded` would return a true value.
+ each member acts as a boolean OR operation. If an argument for
+ :mfcmd:`is-loaded` is a directory and any *modulefile* from the directory has
+ been loaded :mfcmd:`is-loaded` would return a true value.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -244,9 +248,9 @@ the *modulefile* is being loaded.
  provided. If a list contains more than one *collection*, then each member
  acts as a boolean OR operation.
 
- If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the value
- of this variable is appended to the passed *collection* name. In case no
- *collection* argument is provided, a true value will only be returned if
+ If :envvar:`MODULES_COLLECTION_TARGET` is set, a suffix equivalent to the
+ value of this variable is appended to the passed *collection* name. In case
+ no *collection* argument is provided, a true value will only be returned if
  a collection matching currently set target exists.
 
  .. only:: html
@@ -256,8 +260,8 @@ the *modulefile* is being loaded.
 .. mfcmd:: is-used [directory...]
 
  The :mfcmd:`is-used` command returns a true value if any of the listed
- *directories* has been enabled in :envvar:`MODULEPATH` or if any *directory* is
- enabled in case no argument is provided. If a list contains more than one
+ *directories* has been enabled in :envvar:`MODULEPATH` or if any *directory*
+ is enabled in case no argument is provided. If a list contains more than one
  *directory*, then each member acts as a boolean OR operation.
 
  .. only:: html
@@ -267,10 +271,10 @@ the *modulefile* is being loaded.
 .. mfcmd:: is-avail modulefile...
 
  The :mfcmd:`is-avail` command returns a true value if any of the listed
- *modulefiles* exists in enabled :envvar:`MODULEPATH`. If a list contains more than
- one *modulefile*, then each member acts as a boolean OR operation. If an
- argument for :mfcmd:`is-avail` is a directory and a *modulefile* exists in the
- directory :mfcmd:`is-avail` would return a true value.
+ *modulefiles* exists in enabled :envvar:`MODULEPATH`. If a list contains more
+ than one *modulefile*, then each member acts as a boolean OR operation. If an
+ argument for :mfcmd:`is-avail` is a directory and a *modulefile* exists in
+ the directory :mfcmd:`is-avail` would return a true value.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -284,45 +288,48 @@ the *modulefile* is being loaded.
 
  Contains the same *sub-commands* as described in the :ref:`module(1)`
  man page in the :ref:`Module Sub-Commands` section. This command permits a
- *modulefile* to :subcmd:`load` or :subcmd:`unload` other *modulefiles*. No checks are
- made to ensure that the *modulefile* does not try to load itself. Often
- it is useful to have a single *modulefile* that performs a number of
+ *modulefile* to :subcmd:`load` or :subcmd:`unload` other *modulefiles*. No
+ checks are made to ensure that the *modulefile* does not try to load itself.
+ Often it is useful to have a single *modulefile* that performs a number of
  ``module load`` commands. For example, if every user on the system
  requires a basic set of applications loaded, then a core *modulefile*
  would contain the necessary ``module load`` commands.
 
- Command line switches :option:`--auto`, :option:`--no-auto` and :option:`--force` are ignored
- when passed to a :mfcmd:`module` command set in a *modulefile*.
+ Command line switches :option:`--auto`, :option:`--no-auto` and
+ :option:`--force` are ignored when passed to a :mfcmd:`module` command set in
+ a *modulefile*.
 
 .. mfcmd:: module-info option [info-args]
 
- Provide information about the :file:`modulecmd.tcl` program's state. Some of the
- information is specific to the internals of :file:`modulecmd.tcl`. *option*
- is the type of information to be provided, and *info-args* are any
+ Provide information about the :file:`modulecmd.tcl` program's state. Some of
+ the information is specific to the internals of :file:`modulecmd.tcl`.
+ *option* is the type of information to be provided, and *info-args* are any
  arguments needed.
 
  **module-info type**
 
-  Returns either ``C`` or ``Tcl`` to indicate which :command:`module` command is being
-  executed, either the C version or the Tcl-only version, to allow the
-  *modulefile* writer to handle any differences between the two.
+  Returns either ``C`` or ``Tcl`` to indicate which :command:`module` command
+  is being  executed, either the C version or the Tcl-only version, to allow
+  the *modulefile* writer to handle any differences between the two.
 
  **module-info mode** [modetype]
 
-  Returns the current :file:`modulecmd.tcl`'s mode as a string if no *modetype*
-  is given.
+  Returns the current :file:`modulecmd.tcl`'s mode as a string if no
+  *modetype* is given.
 
-  Returns ``1`` if :file:`modulecmd.tcl`'s mode is *modetype*. *modetype* can be:
-  ``load``, ``unload``, ``remove``, ``switch``, ``display``, ``help``, ``test`` or ``whatis``.
+  Returns ``1`` if :file:`modulecmd.tcl`'s mode is *modetype*. *modetype* can
+  be: ``load``, ``unload``, ``remove``, ``switch``, ``display``, ``help``,
+  ``test`` or ``whatis``.
 
  **module-info command** [commandname]
 
   Returns the currently running :file:`modulecmd.tcl`'s command as a string
   if no *commandname* is given.
 
-  Returns ``1`` if :file:`modulecmd.tcl`'s command is *commandname*. *commandname*
-  can be: ``load``, ``unload``, ``reload``, ``source``, ``switch``, ``display``, ``avail``, ``aliases``,
-  ``list``, ``whatis``, ``search``, ``purge``, ``restore``, ``help`` or ``test``.
+  Returns ``1`` if :file:`modulecmd.tcl`'s command is *commandname*.
+  *commandname* can be: ``load``, ``unload``, ``reload``, ``source``,
+  ``switch``, ``display``, ``avail``, ``aliases``, ``list``, ``whatis``,
+  ``search``, ``purge``, ``restore``, ``help`` or ``test``.
 
   .. only:: html
 
@@ -342,22 +349,26 @@ the *modulefile* is being loaded.
 
   Return the current shell under which :file:`modulecmd.tcl` was invoked if
   no *shellname* is given. The current shell is the first parameter of
-  :file:`modulecmd.tcl`, which is normally hidden by the :command:`module` alias.
+  :file:`modulecmd.tcl`, which is normally hidden by the :command:`module`
+  alias.
 
-  If a *shellname* is given, returns ``1`` if :file:`modulecmd.tcl`'s current shell
-  is *shellname*, returns ``0`` otherwise. *shellname* can be: ``sh``, ``bash``, ``ksh``,
-  ``zsh``, ``csh``, ``tcsh``, ``fish``, ``tcl``, ``perl``, ``python``, ``ruby``, ``lisp``, ``cmake``, ``r``.
+  If a *shellname* is given, returns ``1`` if :file:`modulecmd.tcl`'s current
+  shell is *shellname*, returns ``0`` otherwise. *shellname* can be: ``sh``,
+  ``bash``, ``ksh``, ``zsh``, ``csh``, ``tcsh``, ``fish``, ``tcl``, ``perl``,
+  ``python``, ``ruby``, ``lisp``, ``cmake``, ``r``.
 
  **module-info shelltype** [shelltypename]
 
   Return the family of the shell under which *modulefile* was invoked if no
-  *shelltypename* is given. As of :mfcmd:`module-info shell` this depends on the
-  first parameter of :file:`modulecmd.tcl`. The output reflects a shell type
-  determining the shell syntax of the commands produced by :file:`modulecmd.tcl`.
+  *shelltypename* is given. As of :mfcmd:`module-info shell` this depends on
+  the first parameter of :file:`modulecmd.tcl`. The output reflects a shell
+  type determining the shell syntax of the commands produced by
+  :file:`modulecmd.tcl`.
 
-  If a *shelltypename* is given, returns ``1`` if :file:`modulecmd.tcl`'s current
-  shell type is *shelltypename*, returns ``0`` otherwise. *shelltypename*
-  can be: ``sh``, ``csh``, ``fish``, ``tcl``, ``perl``, ``python``, ``ruby``, ``lisp``, ``cmake``, ``r``.
+  If a *shelltypename* is given, returns ``1`` if :file:`modulecmd.tcl`'s
+  current shell type is *shelltypename*, returns ``0`` otherwise.
+  *shelltypename* can be: ``sh``, ``csh``, ``fish``, ``tcl``, ``perl``,
+  ``python``, ``ruby``, ``lisp``, ``cmake``, ``r``.
 
  **module-info alias** name
 
@@ -398,14 +409,14 @@ the *modulefile* is being loaded.
 
  The special *version-name* default specifies the default version to be
  used for module commands, if no specific version is given. This replaces
- the definitions made in the :file:`.version` file in former :file:`modulecmd.tcl`
- releases.
+ the definitions made in the :file:`.version` file in former
+ :file:`modulecmd.tcl` releases.
 
  The parameter *modulefile* may be either
 
  * a fully or partially qualified *modulefile* with name / version. If
-   name is ``.`` (dot) then the current directory name is assumed to be the module
-   name. (Use this for deep *modulefile* directories.)
+   name is ``.`` (dot) then the current directory name is assumed to be the
+   module name. (Use this for deep *modulefile* directories.)
 
  * a symbolic *modulefile* name
 
@@ -444,9 +455,10 @@ the *modulefile* is being loaded.
 .. mfcmd:: module-whatis string
 
  Defines a string which is displayed in case of the invocation of the
- :subcmd:`module whatis<whatis>` command. There may be more than one :mfcmd:`module-whatis`
- line in a *modulefile*. This command takes no actions in case of :subcmd:`load`,
- :subcmd:`display`, etc. invocations of :file:`modulecmd.tcl`.
+ :subcmd:`module whatis<whatis>` command. There may be more than one
+ :mfcmd:`module-whatis` line in a *modulefile*. This command takes no actions
+ in case of :subcmd:`load`, :subcmd:`display`, etc. invocations of
+ :file:`modulecmd.tcl`.
 
  The *string* parameter has to be enclosed in double-quotes if there's more
  than one word specified. Words are defined to be separated by whitespace
@@ -486,17 +498,19 @@ the *modulefile* is being loaded.
 
  Run *string* command through shell. On Unix, command is passed to the
  ``/bin/sh`` shell whereas on Windows it is passed to ``cmd.exe``.
- :file:`modulecmd.tcl` redirects stdout to stderr since stdout would be parsed by
- the evaluating shell. The exit status of the executed command is returned.
+ :file:`modulecmd.tcl` redirects stdout to stderr since stdout would be parsed
+ by the evaluating shell. The exit status of the executed command is returned.
 
 .. mfcmd:: uname field
 
  Provide lookup of system information. Most *field* information are retrieved
- from the ``tcl_platform`` array (see the :manpage:`tclvars(n)` man page). Uname will
- return the string ``unknown`` if information is unavailable for the *field*.
+ from the ``tcl_platform`` array (see the :manpage:`tclvars(n)` man page).
+ Uname will return the string ``unknown`` if information is unavailable for
+ the *field*.
 
- :mfcmd:`uname` will invoke the :manpage:`uname(1)` command in order to get the operating
- system version and :manpage:`domainname(1)` to figure out the name of the domain.
+ :mfcmd:`uname` will invoke the :manpage:`uname(1)` command in order to get
+ the operating system version and :manpage:`domainname(1)` to figure out the
+ name of the domain.
 
  *field* values are:
 
@@ -521,10 +535,10 @@ the *modulefile* is being loaded.
  or *resource-string* is then passed down to be :manpage:`xrdb(1)` command.
 
  *modulefiles* that use this command, should in most cases contain one or
- more :mfcmd:`x-resource` lines, each defining one X11 resource. The :envvar:`DISPLAY`
- environment variable should be properly set and the X11 server should be
- accessible. If :mfcmd:`x-resource` can't manipulate the X11 resource database,
- the *modulefile* will exit with an error message.
+ more :mfcmd:`x-resource` lines, each defining one X11 resource. The
+ :envvar:`DISPLAY` environment variable should be properly set and the X11
+ server should be accessible. If :mfcmd:`x-resource` can't manipulate the X11
+ resource database, the *modulefile* will exit with an error message.
 
  Examples:
 
@@ -560,31 +574,34 @@ is actually a directory, the directory is opened and a search begins for
 an actual *modulefile*. First, :file:`modulecmd.tcl` looks for a file with
 the name :file:`.modulerc` in the directory. If this file exists, its contents
 will be evaluated as if it was a *modulefile* to be loaded. You may place
-:mfcmd:`module-version`, :mfcmd:`module-alias` and :mfcmd:`module-virtual` commands inside
-this file.
+:mfcmd:`module-version`, :mfcmd:`module-alias` and :mfcmd:`module-virtual`
+commands inside this file.
 
-Additionally, before seeking for :file:`.modulerc` files in the module directory,
-the global modulerc file and the :file:`.modulerc` file found at the root of the
-modulepath directory are sourced, too. If a named version default now exists
-for the *modulefile* to be loaded, the assigned *modulefile* now will be
-sourced. Otherwise the file :file:`.version` is looked up in the module directory.
+Additionally, before seeking for :file:`.modulerc` files in the module
+directory, the global modulerc file and the :file:`.modulerc` file found at
+the root of the modulepath directory are sourced, too. If a named version
+default now exists for the *modulefile* to be loaded, the assigned
+*modulefile* now will be sourced. Otherwise the file :file:`.version` is
+looked up in the module directory.
 
-If the :file:`.version` file exists, it is opened and interpreted as Tcl code and
-takes precedence over a :file:`.modulerc` file in the same directory. If the Tcl
-variable ``ModulesVersion`` is set by the :file:`.version` file, :file:`modulecmd.tcl`
-will use the name as if it specifies a *modulefile* in this directory. This
-will become the default *modulefile* in this case. ``ModulesVersion`` cannot
-refer to a *modulefile* located in a different directory.
+If the :file:`.version` file exists, it is opened and interpreted as Tcl code
+and takes precedence over a :file:`.modulerc` file in the same directory. If
+the Tcl variable ``ModulesVersion`` is set by the :file:`.version` file,
+:file:`modulecmd.tcl` will use the name as if it specifies a *modulefile* in
+this directory. This will become the default *modulefile* in this case.
+``ModulesVersion`` cannot refer to a *modulefile* located in a different
+directory.
 
 If ``ModulesVersion`` is a directory, the search begins anew down that
 directory. If the name does not match any files located in the current
 directory, the search continues through the remaining directories in
 :envvar:`MODULEPATH`.
 
-Every :file:`.version` and :file:`.modulerc` file found is interpreted as Tcl code. The
-difference is that :file:`.version` only applies to the current directory, and the
-:file:`.modulerc` applies to the current directory and all subdirectories. Changes
-made in these files will affect the subsequently interpreted *modulefile*.
+Every :file:`.version` and :file:`.modulerc` file found is interpreted as Tcl
+code. The difference is that :file:`.version` only applies to the current
+directory, and the :file:`.modulerc` applies to the current directory and all
+subdirectories. Changes made in these files will affect the subsequently
+interpreted *modulefile*.
 
 If no default version may be figured out, an implicit default is selected when
 this behavior is enabled (see :envvar:`MODULES_IMPLICIT_DEFAULT` in
@@ -592,9 +609,9 @@ this behavior is enabled (see :envvar:`MODULES_IMPLICIT_DEFAULT` in
 explicit default is defined for them, otherwise no default version is found
 and an error is returned. If enabled, then the highest numerically sorted
 *modulefile*, virtual module or module alias under the directory will be used.
-The dictionary comparison method of the :manpage:`lsort(n)` Tcl command is used to
-achieve this sort. If highest numerically sorted element is an alias, search
-continues on its *modulefile* target.
+The dictionary comparison method of the :manpage:`lsort(n)` Tcl command is
+used to achieve this sort. If highest numerically sorted element is an alias,
+search continues on its *modulefile* target.
 
 For example, it is possible for a user to have a directory named X11 which
 simply contains a :file:`.version` file specifying which version of X11 is to
@@ -619,9 +636,10 @@ The equivalent :file:`.modulerc` would look like:
      module-version "./R4" default
 
 If the extended default mechanism is enabled (see
-:envvar:`MODULES_EXTENDED_DEFAULT` in :ref:`module(1)`) the module version specified
-is matched against starting portion of existing module versions, where portion
-is a substring separated from the rest of version string by a ``.`` character.
+:envvar:`MODULES_EXTENDED_DEFAULT` in :ref:`module(1)`) the module version
+specified is matched against starting portion of existing module versions,
+where portion is a substring separated from the rest of version string by a
+``.`` character.
 
 If user names a *modulefile* that cannot be found in the first *modulepath*
 directory, *modulefile* will be searched in next *modulepath* directory
@@ -631,10 +649,10 @@ first looking at the *modulefiles* in the *modulepath* where this alias or
 symbol is defined. If not found, resolution looks at the other *modulepaths*
 in their definition order.
 
-When locating *modulefiles*, if a :file:`.modulerc`, a :file:`.version`, a directory
-or a *modulefile* cannot be read during the search it is simply ignored
-with no error message produced. Visibility of *modulefiles* can thus be
-adapted to the rights the user has been granted. Exception is made when
+When locating *modulefiles*, if a :file:`.modulerc`, a :file:`.version`, a
+directory or a *modulefile* cannot be read during the search it is simply
+ignored with no error message produced. Visibility of *modulefiles* can thus
+be adapted to the rights the user has been granted. Exception is made when
 trying to directly access a directory or a *modulefile*. In this case,
 the access issue is returned as an error message.
 
@@ -650,11 +668,11 @@ Advanced module version specifiers
 ----------------------------------
 
 When the advanced module version specifiers mechanism is enabled (see
-:envvar:`MODULES_ADVANCED_VERSION_SPEC` in :ref:`module(1)`), the specification of
-modulefile passed on Modules specific Tcl commands changes. After the module
-name a version constraint prefixed by the ``@`` character may be added. It
-could be directly appended to the module name or separated from it with a
-space character.
+:envvar:`MODULES_ADVANCED_VERSION_SPEC` in :ref:`module(1)`), the
+specification of modulefile passed on Modules specific Tcl commands changes.
+After the module name a version constraint prefixed by the ``@`` character may
+be added. It could be directly appended to the module name or separated from
+it with a space character.
 
 Constraints can be expressed to refine the selection of module version to:
 
@@ -688,8 +706,8 @@ Modulefile Specific Help
 Users can request help about a specific *modulefile* through the
 :ref:`module(1)` command. The *modulefile* can print helpful information or
 start help oriented programs by defining a ``ModulesHelp`` subroutine. The
-subroutine will be called when the :subcmd:`module help modulefile<help>` command
-is used.
+subroutine will be called when the :subcmd:`module help modulefile<help>`
+command is used.
 
 
 Modulefile Specific Test
@@ -698,19 +716,20 @@ Modulefile Specific Test
 Users can request test of a specific *modulefile* through the :ref:`module(1)`
 command. The *modulefile* can perform some sanity checks on its
 definition or on its underlying programs by defining a ``ModulesTest``
-subroutine. The subroutine will be called when the :subcmd:`module test modulefile<test>`
-command is used. The subroutine should return 1 in case of success. If no
-or any other value is returned, test is considered failed.
+subroutine. The subroutine will be called when the
+:subcmd:`module test modulefile<test>` command is used. The subroutine should
+return 1 in case of success. If no or any other value is returned, test is
+considered failed.
 
 
 Modulefile Display
 ------------------
 
-The :subcmd:`module display modulefile<display>` command will detail all changes that
-will be made to the environment. After displaying all of the environment
-changes :file:`modulecmd.tcl` will call the ``ModulesDisplay`` subroutine. The
-``ModulesDisplay`` subroutine is a good place to put additional descriptive
-information about the *modulefile*.
+The :subcmd:`module display modulefile<display>` command will detail all
+changes that will be made to the environment. After displaying all of the
+environment changes :file:`modulecmd.tcl` will call the ``ModulesDisplay``
+subroutine. The ``ModulesDisplay`` subroutine is a good place to put
+additional descriptive information about the *modulefile*.
 
 
 ENVIRONMENT
@@ -724,8 +743,9 @@ ENVIRONMENT
 SEE ALSO
 --------
 
-:ref:`module(1)`, :manpage:`Tcl(n)`, :manpage:`TclX(n)`, :manpage:`xrdb(1)`, :manpage:`exec(n)`,
-:manpage:`uname(1)`, :manpage:`domainname(1)`, :manpage:`tclvars(n)`, :manpage:`lsort(n)`
+:ref:`module(1)`, :manpage:`Tcl(n)`, :manpage:`TclX(n)`, :manpage:`xrdb(1)`,
+:manpage:`exec(n)`, :manpage:`uname(1)`, :manpage:`domainname(1)`,
+:manpage:`tclvars(n)`, :manpage:`lsort(n)`
 
 
 NOTES

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -271,7 +271,7 @@ the *modulefile* is being loaded.
 .. mfcmd:: module [sub-command] [sub-command-args]
 
  Contains the same *sub-commands* as described in the :ref:`module(1)`
- man page in the Module Sub-Commands section. This command permits a
+ man page in the :ref:`Module Sub-Commands` section. This command permits a
  *modulefile* to :subcmd:`load` or :subcmd:`unload` other *modulefiles*. No checks are
  made to ensure that the *modulefile* does not try to load itself. Often
  it is useful to have a single *modulefile* that performs a number of
@@ -315,7 +315,7 @@ the *modulefile* is being loaded.
  **module-info name**
 
   Return the name of the *modulefile*. This is not the full pathname for
-  *modulefile*. See the Modules Variables section for information on the
+  *modulefile*. See the `Modules Variables`_ section for information on the
   full pathname.
 
  **module-info specified**

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -172,7 +172,7 @@ the *modulefile* is being loaded.
  Append or prepend *value* to environment *variable*. The
  *variable* is a colon, or *delimiter*, separated list such as
  ``PATH=directory:directory:directory``. The default delimiter is a colon
- ':', but an arbitrary one can be given by the *--delim* option. For
+ ':', but an arbitrary one can be given by the ``--delim`` option. For
  example a space can be used instead (which will need to be handled in
  the Tcl specially by enclosing it in " " or { }). A space, however,
  can not be specified by the *--delim=C* form.
@@ -183,7 +183,7 @@ the *modulefile* is being loaded.
  by *_modshare*.
 
  When *value* is already defined in environement *variable*, it is not added
- again except if *--duplicates* option is set.
+ again except if ``--duplicates`` option is set.
 
  If the *variable* is not set, it is created. When a *modulefile* is
  unloaded, **append-path** and **prepend-path** become **remove-path**.
@@ -201,7 +201,7 @@ the *modulefile* is being loaded.
  in *variable* is compared to *value*. If the two match, *value* is removed
  from *variable* if its reference counter is equal to 1 or unknown.
 
- When *--index* option is set, *value* refers to an index in *variable* list.
+ When ``--index`` option is set, *value* refers to an index in *variable* list.
  The string element pointed by this index is set for removal.
 
  Reference counter of *value* in *variable* denotes the number of times
@@ -313,7 +313,7 @@ the *modulefile* is being loaded.
  requires a basic set of applications loaded, then a core *modulefile*
  would contain the necessary **module load** commands.
 
- Command line switches **--auto**, **--no-auto** and **--force** are ignored
+ Command line switches :option:`--auto`, :option:`--no-auto` and :option:`--force` are ignored
  when passed to a **module** command set in a *modulefile*.
 
 .. _module-info:

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -327,7 +327,7 @@ the *modulefile* is being loaded.
 
  **module-info type**
 
-  Returns either "C" or "Tcl" to indicate which **module** command is being
+  Returns either "C" or "Tcl" to indicate which :command:`module` command is being
   executed, either the "C" version or the Tcl-only version, to allow the
   *modulefile* writer to handle any differences between the two.
 
@@ -362,7 +362,7 @@ the *modulefile* is being loaded.
 
   Return the current shell under which :file:`modulecmd.tcl` was invoked if
   no *shellname* is given. The current shell is the first parameter of
-  :file:`modulecmd.tcl`, which is normally hidden by the **module** alias.
+  :file:`modulecmd.tcl`, which is normally hidden by the :command:`module` alias.
 
   If a *shellname* is given, returns 1 if :file:`modulecmd.tcl`'s current shell
   is *shellname*, returns 0 otherwise. *shellname* can be: sh, bash, ksh,


### PR DESCRIPTION
For hyperlinks (in addition to using what Sphinx offers by default) I defined new directives/roles that can be used as ``.. subcmd::`` and ``:subcmd:`` (for the subcommands used for the modules command), and ``.. subcmdfile::`` and ``:subcmdfile:`` (for the subcommands used in modulefile).
I had to separate them in order to not get wrong links because they often have the same name but two different locations where they are documented.

I introduced usage of the ``.. versionadded::`` and  ``.. versionchanged::`` directives.

Some typos and grammar were also fixed.