### PR TITLE
Add "my" for perl's $_mlstatus

### DIFF
--- a/modulecmd.tcl.in
+++ b/modulecmd.tcl.in
@@ -388,7 +388,7 @@ proc renderFalse {} {
             puts stdout {set errorlevel=1}
          }
          perl {
-            puts stdout {my $_mlstatus = 0;}
+            puts stdout {{ no strict 'vars'; $_mlstatus = 0; }}
          }
          python {
             puts stdout {_mlstatus = False}
@@ -429,7 +429,7 @@ proc renderTrue {} {
          puts stdout {set errorlevel=0}
       }
       perl {
-         puts stdout {my $_mlstatus = 1;}
+         puts stdout {{ no strict 'vars'; $_mlstatus = 1; }}
       }
       python {
          puts stdout {_mlstatus = True}
@@ -472,7 +472,7 @@ proc renderText {text} {
          }
       }
       perl {
-         puts stdout "my \$_mlstatus = '$text';"
+         puts stdout "{ no strict 'vars'; \$_mlstatus = '$text'; }"
       }
       python {
          puts stdout "_mlstatus = '$text'"

--- a/modulecmd.tcl.in
+++ b/modulecmd.tcl.in
@@ -388,7 +388,7 @@ proc renderFalse {} {
             puts stdout {set errorlevel=1}
          }
          perl {
-            puts stdout {$_mlstatus = 0;}
+            puts stdout {my $_mlstatus = 0;}
          }
          python {
             puts stdout {_mlstatus = False}
@@ -429,7 +429,7 @@ proc renderTrue {} {
          puts stdout {set errorlevel=0}
       }
       perl {
-         puts stdout {$_mlstatus = 1;}
+         puts stdout {my $_mlstatus = 1;}
       }
       python {
          puts stdout {_mlstatus = True}
@@ -472,7 +472,7 @@ proc renderText {text} {
          }
       }
       perl {
-         puts stdout "\$_mlstatus = '$text';"
+         puts stdout "my \$_mlstatus = '$text';"
       }
       python {
          puts stdout "_mlstatus = '$text'"

--- a/testsuite/modules.00-init/006-procs.exp
+++ b/testsuite/modules.00-init/006-procs.exp
@@ -82,7 +82,7 @@ proc shell_err {test_shell {nb_err 1} {re_mode 0}} {
             set answer "set errorlevel=1"
         }
         {perl} {
-            set answer "${esc}\$_mlstatus = 0;"
+            set answer "{ no strict 'vars'; ${esc}\$_mlstatus = 0; }"
         }
         {python} {
             set answer "_mlstatus = False"
@@ -131,7 +131,7 @@ proc shell_ok {test_shell {re_mode 0}} {
             set answer "_mlstatus = true"
         }
         {perl} {
-            set answer "${esc}\$_mlstatus = 1;"
+            set answer "{ no strict 'vars'; ${esc}\$_mlstatus = 1; }"
         }
         {lisp} {
             set answer "t"
@@ -190,7 +190,7 @@ proc shell_text {test_shell val {re_mode 0}} {
             set answer "_mlstatus = '$val'"
         }
         {perl} {
-            set answer "${esc}\$_mlstatus = '$val';"
+            set answer "{ no strict 'vars'; ${esc}\$_mlstatus = '$val'; }"
         }
         {lisp} {
             set answer "${esc}(message \"$val\"${esc})"


### PR DESCRIPTION
Since this variable is always rendered it might be evaluated in a strict scope and fail with the following error: `Global symbol "$_mlstatus" requires explicit package name (did you forget to declare "my $_mlstatus"?)`