### PR TITLE
bash_completion: fix ml no space between -modules

### DIFF
--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -246,14 +246,14 @@ if $(type -t ml >/dev/null); then
                 -*)     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
                         loaded_modules=""
                         for i in ${LOADEDMODULES//:/ }; do
-                            loaded_modules+="-${i}"
+                            loaded_modules+="-${i} "
                         done
                         COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "$load_opts $loaded_modules" -- "$cur") );;
                 *)       _module_comgen_words_and_files "$load_opts $(_module_not_yet_loaded $cur)" "$cur"
                         COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "$opts $cmds" -- "$cur") )
                         loaded_modules=""
                         for i in ${LOADEDMODULES//:/ }; do
-                            loaded_modules+="-${i}"
+                            loaded_modules+="-${i} "
                         done
                         COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "$load_opts $loaded_modules" -- "$cur") );;
                 esac


### PR DESCRIPTION
Hello,

Just a little fix for ml bash_completion, add space between loaded modules.

Before: 
$ ml -<tab> <tab>
-intel-mpi

After:
$ ml -<tab> <tab>
-intel -mpi

Best,
Adrien