### PR TITLE
Use file normalise and load library using absolute path

### DIFF
--- a/modulecmd.tcl.in
+++ b/modulecmd.tcl.in
@@ -11085,7 +11085,7 @@ if {[catch {
    # Load extension library if enabled
    @libtclenvmodules@if {[file readable [getConf tcl_ext_lib]]} {
    @libtclenvmodules@   reportDebug "Load Tcl extension library ([getConf tcl_ext_lib])"
-   @libtclenvmodules@   load [getConf tcl_ext_lib] Envmodules
+   @libtclenvmodules@   load [file normalize [getConf tcl_ext_lib]] Envmodules
    @libtclenvmodules@   set g_tclextlib_loaded 1
    @libtclenvmodules@}
    # use fallback procs if extension library is not loaded

--- a/testsuite/modules.00-init/150-access-init.exp
+++ b/testsuite/modules.00-init/150-access-init.exp
@@ -54,15 +54,17 @@ if {[info exists tclextlib_file]} {
     # replace Tcl extension library by a non lib file
     file rename $tclextlib_file $tclextlib_file.orig
     file copy lib/envmodules.c $tclextlib_file
+    set tclextlib_file_abs_re [regsub -all "\(\[.+?\]\)" [file normalize $tclextlib_file] {\\\1}]
     if {$tcl_platform(os) eq {Darwin}} {
-        set tserr "$error_msgs: dlopen\\\($tclextlib_file,.*"
+        set tserr "$error_msgs: dlopen\\\($tclextlib_file_abs_re,.*"
     } else {
-        set tserr "$error_msgs: couldn't load file \"$tclextlib_file\":.*"
+        set tserr "$error_msgs: couldn't load file \"$tclextlib_file_abs_re\":.*"
     }
     testouterr_cmd_re sh {-V} {} $tserr
     file delete $tclextlib_file
     file rename $tclextlib_file.orig $tclextlib_file
     unset tserr
+    unset tclextlib_file_abs_re
 }
 
 # restrict read access to site-specific configuration script


### PR DESCRIPTION
These changes result in no failed tests on macOS 10.15 as seen in #344, and might be useful for #304.
