### PR TITLE
Replace completion helper vars with their content

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -173,6 +173,9 @@ Modules 4.7.0 (not yet released)
   width. (fix issues #379 and #381)
 * Correct :subcmd:`config` sub-command to set :mconfig:`nearly_forbidden_days`
   configuration. (fix issue #380)
+* Init: reduce usage of helper variables in :file:`bash_completion` and
+  :file:`tcsh_completion` that are showing up in the output of the shell's
+  ``set`` command. (fix issue #382 with contribution from Colin Marquardt)
 
 
 .. _4.6 release notes:

--- a/init/Makefile
+++ b/init/Makefile
@@ -133,6 +133,22 @@ quarvarsre += $(foreach vv,$(quarantinevars),$(call runenvvarre,$(firstword\
 quarvarsre += s/@.*RUNENV_VAR.*@//;'
 endif
 
+# define variables for shell completion
+comp_cmds := add apropos aliases avail append-path clear config del display help initadd initclear initlist initprepend initrm is-loaded is-saved is-used is-avail info-loaded keyword list load path paths purge prepend-path refresh reload restore rm remove remove-path save savelist saveshow saverm search show sh-to-mod source swap switch test unload unuse use whatis
+comp_opts := -D -h -s -T -v -V --debug --help --silent --trace --verbose --version --paginate --no-pager --color --color=
+comp_load_opts := --auto --no-auto --force -f --icase -i
+comp_list_opts := -j -l -t --json --long --terse
+comp_clear_opts := --force -f
+comp_avail_opts := -a -C -d -i -j -L -l -S -t --all --contains --default --icase --json --latest --long --starts-with --terse --indepth --no-indepth
+comp_mfile_opts := -i --icase
+comp_whatis_opts := -a -i -j --all --icase --json
+comp_search_opts := -a -j --all --json
+comp_aliases_opts := -a --all
+comp_isavail_opts := -a -i --all --icase
+comp_path_opts := -d --delim --duplicates
+comp_rm_path_opts := -d --delim --index
+comp_config_opts := --dump-state --reset advanced_version_spec auto_handling avail_indepth collection_pin_version collection_target color colors contact extended_default extra_siteconfig home icase implicit_default implicit_requirement locked_configs mcookie_version_check ml nearly_forbidden_days pager rcfile run_quarantine search_match set_shell_startup shells_with_ksh_fpath silent_shell_debug tag_abbrev tag_color_name term_background unload_match_order verbosity wa_277
+
 define translate-in-script
 sed -e 's|@prefix@|$(prefix)|g' \
 	-e 's|@baseprefix@|$(baseprefix)|g' \
@@ -142,6 +158,20 @@ sed -e 's|@prefix@|$(prefix)|g' \
 	-e 's|@modulefilesdir@|$(modulefilesdir)|g' \
 	-e 's|@bindir@|$(bindir)|g' \
 	-e 's|@mandir@|$(mandir)|g' \
+	-e 's|@comp_cmds@|$(comp_cmds)|g' \
+	-e 's|@comp_opts@|$(comp_opts)|g' \
+	-e 's|@comp_load_opts@|$(comp_load_opts)|g' \
+	-e 's|@comp_list_opts@|$(comp_list_opts)|g' \
+	-e 's|@comp_clear_opts@|$(comp_clear_opts)|g' \
+	-e 's|@comp_avail_opts@|$(comp_avail_opts)|g' \
+	-e 's|@comp_mfile_opts@|$(comp_mfile_opts)|g' \
+	-e 's|@comp_whatis_opts@|$(comp_whatis_opts)|g' \
+	-e 's|@comp_search_opts@|$(comp_search_opts)|g' \
+	-e 's|@comp_aliases_opts@|$(comp_aliases_opts)|g' \
+	-e 's|@comp_isavail_opts@|$(comp_isavail_opts)|g' \
+	-e 's|@comp_path_opts@|$(comp_path_opts)|g' \
+	-e 's|@comp_rm_path_opts@|$(comp_rm_path_opts)|g' \
+	-e 's|@comp_config_opts@|$(comp_config_opts)|g' \
 	-e '$(setmanpathre)' \
 	-e '$(appendmanpathre)' \
 	-e '$(prependmanpathre)' \

--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -107,62 +107,33 @@ _module() {
 
     COMPREPLY=()
 
-    cmds="add apropos aliases avail append-path clear config del display help\
-        initadd initclear initlist initprepend initrm is-loaded is-saved\
-        is-used is-avail info-loaded keyword list load path paths purge\
-        prepend-path refresh reload restore rm remove remove-path save\
-        savelist saveshow saverm search show sh-to-mod source swap switch\
-        test unload unuse use whatis"
-
-    opts="-D -h -s -T -v -V --debug --help --silent --trace --verbose\
-        --version --paginate --no-pager --color --color="
-    load_opts="--auto --no-auto --force -f -i --icase"
-    list_opts="-j -l -t --json --long --terse"
-    clear_opts="--force -f"
-    path_opts="-d --delim --duplicates"
-    rm_path_opts="-d --delim --index"
-    avail_opts="-a -C -d -j -i -L -l -S -t --all --contains --default --icase\
-        --json --latest --long --starts-with --terse --indepth --no-indepth"
-    isavail_opts="-a -i --all --icase"
-    aliases_opts="-a --all"
-    mfile_opts="-i --icase"
-    search_opts="-a -j --all --json"
-    whatis_opts="-a -i -j --all --icase --json"
-    config_opts="--dump-state --reset advanced_version_spec auto_handling\
-        avail_indepth collection_pin_version collection_target color colors\
-        contact extended_default extra_siteconfig home icase implicit_default\
-        implicit_requirement locked_configs mcookie_version_check ml\
-        nearly_forbidden_days pager rcfile run_quarantine search_match\
-        set_shell_startup shells_with_ksh_fpath silent_shell_debug tag_abbrev\
-        tag_color_name term_background unload_match_order verbosity wa_277"
-
     case "$prev" in
-    add|load)       _module_comgen_words_and_files "$load_opts $(_module_not_yet_loaded $cur)" "$cur";;
-    avail)          _module_comgen_words_and_files "$avail_opts $(_module_avail $cur)" "$cur";;
-    aliases)  COMPREPLY=( $(compgen -W "$aliases_opts" -- "$cur") );;
-    list|savelist)  COMPREPLY=( $(compgen -W "$list_opts" -- "$cur") );;
-    clear)  COMPREPLY=( $(compgen -W "$clear_opts" -- "$cur") );;
+    add|load)       _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded $cur)" "$cur";;
+    avail)          _module_comgen_words_and_files "@comp_avail_opts@ $(_module_avail $cur)" "$cur";;
+    aliases)  COMPREPLY=( $(compgen -W "@comp_aliases_opts@" -- "$cur") );;
+    list|savelist)  COMPREPLY=( $(compgen -W "@comp_list_opts@" -- "$cur") );;
+    clear)  COMPREPLY=( $(compgen -W "@comp_clear_opts@" -- "$cur") );;
     restore|save|saveshow|saverm|is-saved)
                     COMPREPLY=( $(compgen -W "$(_module_savelist)" -- "$cur") );;
     rm|del|remove|unload|switch|swap)
-                    COMPREPLY=( $(compgen -W "$load_opts ${LOADEDMODULES//:/ }" -- "$cur") );;
+                    COMPREPLY=( $(compgen -W "@comp_load_opts@ ${LOADEDMODULES//:/ }" -- "$cur") );;
     unuse|is-used)  COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "$cur") );;
     use|-a|--append)   ;;               # let readline handle the completion
     display|help|show|test|path|paths|is-loaded|info-loaded)
-                    _module_comgen_words_and_files "$mfile_opts $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_mfile_opts@ $(_module_avail $cur)" "$cur";;
     is-avail)
-                    _module_comgen_words_and_files "$isavail_opts $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_isavail_opts@ $(_module_avail $cur)" "$cur";;
     whatis)
-                    _module_comgen_words_and_files "$whatis_opts $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_whatis_opts@ $(_module_avail $cur)" "$cur";;
     apropos|keyword|search)
-                    COMPREPLY=( $(compgen -W "$search_opts" -- "$cur") );;
-    config|--reset) COMPREPLY=( $(compgen -W "$config_opts" -- "$cur") );;
+                    COMPREPLY=( $(compgen -W "@comp_search_opts@" -- "$cur") );;
+    config|--reset) COMPREPLY=( $(compgen -W "@comp_config_opts@" -- "$cur") );;
     -h|--help|-V|--version|purge|refresh|reload|sh-to-mod|source)
                     ;;
     append-path|prepend-path)
-                    COMPREPLY=( $(compgen -W "$path_opts" -- "$cur") );;
+                    COMPREPLY=( $(compgen -W "@comp_path_opts@" -- "$cur") );;
     remove-path)
-                    COMPREPLY=( $(compgen -W "$rm_path_opts" -- "$cur") );;
+                    COMPREPLY=( $(compgen -W "@comp_rm_path_opts@" -- "$cur") );;
     initadd|initclear|initlist|initprepend|initrm)
                     ;;
     *)  if test $COMP_CWORD -gt 2
@@ -174,8 +145,8 @@ _module() {
             ls)     COMPREPLY="list";;      # map ls -> list
             sw*)    COMPREPLY="switch";;
 
-            -*)     COMPREPLY=( $(compgen -W "$opts" -- "$cur") );;
-            *)      COMPREPLY=( $(compgen -W "$opts $cmds" -- "$cur") );;
+            -*)     COMPREPLY=( $(compgen -W "@comp_opts@" -- "$cur") );;
+            *)      COMPREPLY=( $(compgen -W "@comp_opts@ @comp_cmds@" -- "$cur") );;
             esac
         fi;;
     esac
@@ -188,62 +159,33 @@ if $(type -t ml >/dev/null); then
 
         COMPREPLY=()
 
-        cmds="add apropos aliases avail append-path clear config del display help\
-            initadd initclear initlist initprepend initrm is-loaded is-saved\
-            is-used is-avail info-loaded keyword list load path paths purge\
-            prepend-path refresh reload restore rm remove remove-path save\
-            savelist saveshow saverm search show sh-to-mod source swap switch\
-            test unload unuse use whatis"
-
-        opts="-D -h -s -T -v -V --debug --help --silent --trace --verbose\
-            --version --paginate --no-pager --color --color="
-        load_opts="--auto --no-auto --force -f -i --icase"
-        list_opts="-j -l -t --json --long --terse"
-        clear_opts="--force -f"
-        path_opts="-d --delim --duplicates"
-        rm_path_opts="-d --delim --index"
-        avail_opts="-a -C -d -j -i -L -l -S -t --all --contains --default --icase\
-            --json --latest --long --starts-with --terse --indepth --no-indepth"
-        isavail_opts="-a -i --all --icase"
-        aliases_opts="-a --all"
-        mfile_opts="-i --icase"
-        search_opts="-a -j --all --json"
-        whatis_opts="-a -i -j --all --icase --json"
-        config_opts="--dump-state --reset advanced_version_spec auto_handling\
-            avail_indepth collection_pin_version collection_target color colors\
-            contact extended_default extra_siteconfig home icase implicit_default\
-            implicit_requirement locked_configs mcookie_version_check ml\
-            nearly_forbidden_days pager rcfile run_quarantine search_match\
-            set_shell_startup shells_with_ksh_fpath silent_shell_debug tag_abbrev\
-            tag_color_name term_background unload_match_order verbosity wa_277"
-
         case "$prev" in
-        add|load)       _module_comgen_words_and_files "$load_opts $(_module_not_yet_loaded $cur)" "$cur";;
-        avail)          _module_comgen_words_and_files "$avail_opts $(_module_avail $cur)" "$cur";;
-        aliases)  COMPREPLY=( $(compgen -W "$aliases_opts" -- "$cur") );;
-        list|savelist)  COMPREPLY=( $(compgen -W "$list_opts" -- "$cur") );;
-        clear)  COMPREPLY=( $(compgen -W "$clear_opts" -- "$cur") );;
+        add|load)       _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded $cur)" "$cur";;
+        avail)          _module_comgen_words_and_files "@comp_avail_opts@ $(_module_avail $cur)" "$cur";;
+        aliases)  COMPREPLY=( $(compgen -W "@comp_aliases_opts@" -- "$cur") );;
+        list|savelist)  COMPREPLY=( $(compgen -W "@comp_list_opts@" -- "$cur") );;
+        clear)  COMPREPLY=( $(compgen -W "@comp_clear_opts@" -- "$cur") );;
         restore|save|saveshow|saverm|is-saved)
                         COMPREPLY=( $(compgen -W "$(_module_savelist)" -- "$cur") );;
         rm|del|remove|unload|switch|swap)
-                        COMPREPLY=( $(compgen -W "$load_opts ${LOADEDMODULES//:/ }" -- "$cur") );;
+                        COMPREPLY=( $(compgen -W "@comp_load_opts@ ${LOADEDMODULES//:/ }" -- "$cur") );;
         unuse|is-used)  COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "$cur") );;
         use|-a|--append)   ;;               # let readline handle the completion
         display|help|show|test|path|paths|is-loaded|info-loaded)
-                        _module_comgen_words_and_files "$mfile_opts $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_mfile_opts@ $(_module_avail $cur)" "$cur";;
         is-avail)
-                        _module_comgen_words_and_files "$isavail_opts $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_isavail_opts@ $(_module_avail $cur)" "$cur";;
         whatis)
-                        _module_comgen_words_and_files "$whatis_opts $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_whatis_opts@ $(_module_avail $cur)" "$cur";;
         apropos|keyword|search)
-                        COMPREPLY=( $(compgen -W "$search_opts" -- "$cur") );;
-        config|--reset) COMPREPLY=( $(compgen -W "$config_opts" -- "$cur") );;
+                        COMPREPLY=( $(compgen -W "@comp_search_opts@" -- "$cur") );;
+        config|--reset) COMPREPLY=( $(compgen -W "@comp_config_opts@" -- "$cur") );;
         -h|--help|-V|--version|purge|refresh|reload|sh-to-mod|source)
                         ;;
         append-path|prepend-path)
-                        COMPREPLY=( $(compgen -W "$path_opts" -- "$cur") );;
+                        COMPREPLY=( $(compgen -W "@comp_path_opts@" -- "$cur") );;
         remove-path)
-                        COMPREPLY=( $(compgen -W "$rm_path_opts" -- "$cur") );;
+                        COMPREPLY=( $(compgen -W "@comp_rm_path_opts@" -- "$cur") );;
         initadd|initclear|initlist|initprepend|initrm)
                         ;;
         *)  if test $COMP_CWORD -gt 2
@@ -255,19 +197,19 @@ if $(type -t ml >/dev/null); then
                 ls)     COMPREPLY="list";;      # map ls -> list
                 sw*)    COMPREPLY="switch";;
 
-                -*)     COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+                -*)     COMPREPLY=( $(compgen -W "@comp_opts@" -- "$cur") )
                         loaded_modules=""
                         for i in ${LOADEDMODULES//:/ }; do
                             loaded_modules+="-${i} "
                         done
-                        COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "$load_opts $loaded_modules" -- "$cur") );;
-                *)       _module_comgen_words_and_files "$load_opts $(_module_not_yet_loaded $cur)" "$cur"
-                        COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "$opts $cmds" -- "$cur") )
+                        COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "@comp_load_opts@ $loaded_modules" -- "$cur") );;
+                *)       _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded $cur)" "$cur"
+                        COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "@comp_opts@ @comp_cmds@" -- "$cur") )
                         loaded_modules=""
                         for i in ${LOADEDMODULES//:/ }; do
                             loaded_modules+="-${i} "
                         done
-                        COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "$load_opts $loaded_modules" -- "$cur") );;
+                        COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "@comp_load_opts@ $loaded_modules" -- "$cur") );;
                 esac
             fi;;
         esac

--- a/init/tcsh_completion.in
+++ b/init/tcsh_completion.in
@@ -37,48 +37,32 @@ alias _module_not_yet_loaded '\\
 
 alias _module_modulepath 'echo ${MODULEPATH} | sed '"'"'s/:/\n/g;'"'"' '
 
-set module_cmds = "add apropos aliases avail append-path clear config del display help initadd initclear initlist initprepend initrm is-loaded is-saved is-used is-avail info-loaded keyword list load path paths purge prepend-path refresh reload restore rm remove remove-path save savelist saveshow saverm search show sh-to-mod source swap switch test unload unuse use whatis"
-
-set module_opts = "-D -h -s -T -v -V --debug --help --silent --trace --verbose --version --paginate --no-pager --color --color="
-set module_load_opts = "--auto --no-auto --force -f --icase -i"
-set module_list_opts = "-j -l -t --json --long --terse"
-set module_clear_opts = "--force -f"
-set module_avail_opts = "-a -C -d -i -j -L -l -S -t --all --contains --default --icase --json --latest --long --starts-with --terse --indepth --no-indepth"
-set module_mfile_opts = "-i --icase"
-set module_whatis_opts = "-a -i -j --all --icase --json"
-set module_search_opts = "-a -j --all --json"
-set module_aliases_opts = "-a --all"
-set module_isavail_opts = "-a -i --all --icase"
-set module_path_opts = "-d --delim --duplicates"
-set module_rm_path_opts = "-d --delim --index"
-set module_config_opts = "--dump-state --reset advanced_version_spec auto_handling avail_indepth collection_pin_version collection_target color colors contact extended_default extra_siteconfig home icase implicit_default implicit_requirement locked_configs mcookie_version_check ml nearly_forbidden_days pager rcfile run_quarantine search_match set_shell_startup shells_with_ksh_fpath silent_shell_debug tag_abbrev tag_color_name term_background unload_match_order verbosity wa_277"
-
 complete module 'n/help/`_module_avail`/' \
-        'n/add/`_module_not_yet_loaded; echo ${module_load_opts}`/' \
-        'n/load/`_module_not_yet_loaded; echo ${module_load_opts}`/' \
-        'n/rm/`_module_loaded; echo ${module_load_opts}`/' \
-        'n/del/`_module_loaded; echo ${module_load_opts}`/' \
-        'n/remove/`_module_loaded; echo ${module_load_opts}`/' \
-        'n/unload/`_module_loaded; echo ${module_load_opts}`/' \
-        'n/swap/`_module_loaded; echo ${module_load_opts}`/' \
-        'N/swap/`_module_not_yet_loaded; echo ${module_load_opts}`/' \
-        'n/switch/`_module_loaded; echo ${module_load_opts}`/' \
-        'N/switch/`_module_not_yet_loaded; echo ${module_load_opts}`/' \
-        'n/show/`_module_avail; echo ${module_mfile_opts}`/' \
-        'n/display/`_module_avail; echo ${module_mfile_opts}`/' \
-        'n/test/`_module_avail; echo ${module_mfile_opts}`/' \
-        "n/list/(${module_list_opts})/" \
-        'n/avail/`_module_avail; echo ${module_avail_opts}`/' \
-        'n/is-avail/`_module_avail; echo ${module_isavail_opts}`/' \
-        'n/is-loaded/`_module_avail; echo ${module_mfile_opts}`/' \
-        'n/info-loaded/`_module_avail; echo ${module_mfile_opts}`/' \
+        'n/add/`_module_not_yet_loaded; echo "@comp_load_opts@"`/' \
+        'n/load/`_module_not_yet_loaded; echo "@comp_load_opts@"`/' \
+        'n/rm/`_module_loaded; echo "@comp_load_opts@"`/' \
+        'n/del/`_module_loaded; echo "@comp_load_opts@"`/' \
+        'n/remove/`_module_loaded; echo "@comp_load_opts@"`/' \
+        'n/unload/`_module_loaded; echo "@comp_load_opts@"`/' \
+        'n/swap/`_module_loaded; echo "@comp_load_opts@"`/' \
+        'N/swap/`_module_not_yet_loaded; echo "@comp_load_opts@"`/' \
+        'n/switch/`_module_loaded; echo "@comp_load_opts@"`/' \
+        'N/switch/`_module_not_yet_loaded; echo "@comp_load_opts@"`/' \
+        'n/show/`_module_avail; echo "@comp_mfile_opts@"`/' \
+        'n/display/`_module_avail; echo "@comp_mfile_opts@"`/' \
+        'n/test/`_module_avail; echo "@comp_mfile_opts@"`/' \
+        "n/list/(@comp_list_opts@)/" \
+        'n/avail/`_module_avail; echo "@comp_avail_opts@"`/' \
+        'n/is-avail/`_module_avail; echo "@comp_isavail_opts@"`/' \
+        'n/is-loaded/`_module_avail; echo "@comp_mfile_opts@"`/' \
+        'n/info-loaded/`_module_avail; echo "@comp_mfile_opts@"`/' \
         'n/restore/`_module_savelist`/' \
-        "n/savelist/(${module_list_opts})/" \
+        "n/savelist/(@comp_list_opts@)/" \
         'n/saveshow/`_module_savelist`/' \
         'n/saverm/`_module_savelist`/' \
         'n/save/`_module_savelist`/' \
         'n/is-saved/`_module_savelist`/' \
-        "n/aliases/(${module_aliases_opts})/" \
+        "n/aliases/(@comp_aliases_opts@)/" \
         'n/use/d/' \
         'N/use/d/' \
         'n/unuse/`_module_modulepath`/' \
@@ -86,12 +70,12 @@ complete module 'n/help/`_module_avail`/' \
         'n/purge/n/' \
         'n/refresh/n/' \
         'n/reload/n/' \
-        'n/whatis/`_module_avail; echo ${module_whatis_opts}`/' \
-        "n/apropos/(${module_search_opts})/" \
-        "n/search/(${module_search_opts})/" \
-        "n/keyword/(${module_search_opts})/" \
-        'n/paths/`_module_avail; echo ${module_mfile_opts}`/' \
-        'n/path/`_module_avail; echo ${module_mfile_opts}`/' \
+        'n/whatis/`_module_avail; echo "@comp_whatis_opts@"`/' \
+        "n/apropos/(@comp_search_opts@)/" \
+        "n/search/(@comp_search_opts@)/" \
+        "n/keyword/(@comp_search_opts@)/" \
+        'n/paths/`_module_avail; echo "@comp_mfile_opts@"`/' \
+        'n/path/`_module_avail; echo "@comp_mfile_opts@"`/' \
         'n/sh-to-mod/n/' \
         'n/source/n/' \
         'n/initadd/n/' \
@@ -99,17 +83,16 @@ complete module 'n/help/`_module_avail`/' \
         'n/initrm/n/' \
         'n/initlist/n/' \
         'n/initclear/n/' \
-        "n/append-path/(${module_path_opts})/" \
-        "n/prepend-path/(${module_path_opts})/" \
-        "n/remove-path/(${module_rm_path_opts})/" \
-        "n/clear/(${module_clear_opts})/" \
-        "n/config/(${module_config_opts})/" \
-        "n/--reset/(${module_config_opts})/" \
+        "n/append-path/(@comp_path_opts@)/" \
+        "n/prepend-path/(@comp_path_opts@)/" \
+        "n/remove-path/(@comp_rm_path_opts@)/" \
+        "n/clear/(@comp_clear_opts@)/" \
+        "n/config/(@comp_config_opts@)/" \
+        "n/--reset/(@comp_config_opts@)/" \
         'n/-h/n/' \
         'n/--help/n/' \
         'n/-V/n/' \
         'n/--version/n/' \
         'C/sw*/(switch)/' \
-        "p/1/(${module_cmds} ${module_opts})/" \
-        "n/-*/(${module_cmds})/" 
-
+        "p/1/(@comp_cmds@ @comp_opts@)/" \
+        "n/-*/(@comp_cmds@)/"


### PR DESCRIPTION
This is done for tcsh and bash where those variables clutter the environment.

Closes #382