### PR TITLE
lib: handle `sysconf` failure in `InitStateUsergroupsObjCmd`

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -1,4 +1,4 @@
-personal_ws-1.1 en 788
+personal_ws-1.1 en 795
 ABBRVLIST
 ActiveTcl
 Adrien
@@ -40,6 +40,7 @@ Dimitri
 EnvModEscPS
 EnvModEscS
 EnvironmentModules
+Envmodules
 ErrorAndExit
 FOOENV
 FOOVERSION
@@ -70,6 +71,7 @@ ICase
 INPROGRESS
 IcAsE
 Ileaf
+InitStateUsergroupsObjCmd
 InternalBug
 Jens
 Jesper
@@ -96,6 +98,7 @@ LoadedCompilerMatches
 LoadedMPIMatches
 LoadedMpiMatches
 Lua
+Lukás
 MANPATH
 MKL
 MODLIST
@@ -204,6 +207,7 @@ Wenzler
 Wesarg
 YYYY
 Za
+Zaoral
 aL
 abfef
 acml
@@ -415,6 +419,7 @@ idx
 indepth
 init
 initStateClockSeconds
+initStateUsergroups
 initadd
 initclear
 initconf
@@ -446,6 +451,7 @@ lappendConf
 lappendState
 lexicographically
 liba
+libc
 libdir
 libexec
 libexecdir
@@ -696,6 +702,7 @@ symlinks
 syntaxes
 sys
 syscall
+sysconf
 sysname
 tSome
 taglist

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,8 @@ TEST_PREREQ += lib/libtestutil-closedir$(SHLIB_SUFFIX) \
 	lib/libtestutil-dupgetgroups$(SHLIB_SUFFIX) \
 	lib/libtestutil-getgrgid$(SHLIB_SUFFIX) \
 	lib/libtestutil-time$(SHLIB_SUFFIX) \
-	lib/libtestutil-mktime$(SHLIB_SUFFIX)
+	lib/libtestutil-mktime$(SHLIB_SUFFIX) \
+	lib/libtestutil-sysconf$(SHLIB_SUFFIX)
 endif
 endif
 
@@ -464,6 +465,9 @@ lib/libtestutil-time$(SHLIB_SUFFIX):
 	$(MAKE) --no-print-directory -C lib $(@F)
 
 lib/libtestutil-mktime$(SHLIB_SUFFIX):
+	$(MAKE) --no-print-directory -C lib $(@F)
+
+lib/libtestutil-sysconf$(SHLIB_SUFFIX):
 	$(MAKE) --no-print-directory -C lib $(@F)
 
 # example configs for test rules
@@ -891,7 +895,7 @@ $(V).SILENT: initdir pkgdoc doc version.inc contrib/rpm/environment-modules.spec
 	script/add.modules script/gitlog2changelog.py script/modulecmd \
 	lib/libtclenvmodules$(SHLIB_SUFFIX) lib/libtestutil-closedir$(SHLIB_SUFFIX) \
 	lib/libtestutil-getpwuid$(SHLIB_SUFFIX) lib/libtestutil-getgroups$(SHLIB_SUFFIX) \
-	lib/libtestutil-0getgroups$(SHLIB_SUFFIX) \
+	lib/libtestutil-0getgroups$(SHLIB_SUFFIX) lib/libtestutil-sysconf$(SHLIB_SUFFIX) \
 	lib/libtestutil-dupgetgroups$(SHLIB_SUFFIX) lib/libtestutil-getgrgid$(SHLIB_SUFFIX) \
 	lib/libtestutil-time$(SHLIB_SUFFIX) lib/libtestutil-mktime$(SHLIB_SUFFIX) \
 	testsuite/example/.modulespath testsuite/example/modulespath-wild \

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -195,6 +195,8 @@ Modules 5.1.0 (not yet released)
 * Update definition of the ``module()`` python function and python
   initialization script to explicitly send output to ``sys.stderr`` to get the
   ability to catch this content.
+* Lib: handle ``sysconf`` error in function implementing the
+  ``initStateUsergroups`` procedure. (contribution from Lukáš Zaoral)
 
 .. _Code of conduct: https://github.com/cea-hpc/modules/blob/master/CODE_OF_CONDUCT.md
 .. _codespell: https://github.com/codespell-project/codespell

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -15,6 +15,7 @@
 /libtestutil-getgrgid.so
 /libtestutil-time.so
 /libtestutil-mktime.so
+/libtestutil-sysconf.so
 /envmodules.c.gcov
 /envmodules.gcda
 /envmodules.gcno

--- a/lib/Makefile.in
+++ b/lib/Makefile.in
@@ -64,6 +64,10 @@ libtestutil-mktime@SHLIB_SUFFIX@: testutil-mktime.c
 	$(ECHO_CC)
 	$(LDCC) $< -o $@
 
+libtestutil-sysconf@SHLIB_SUFFIX@: testutil-sysconf.c
+	$(ECHO_CC)
+	$(LDCC) $< -o $@
+
 clean:
 	rm -f envmodules.o
 	rm -f libtclenvmodules@TCL_SHLIB_SUFFIX@
@@ -75,6 +79,7 @@ clean:
 	rm -f libtestutil-getgrgid@SHLIB_SUFFIX@
 	rm -f libtestutil-time@SHLIB_SUFFIX@
 	rm -f libtestutil-mktime@SHLIB_SUFFIX@
+	rm -f libtestutil-sysconf@SHLIB_SUFFIX@
 	rm -f envmodules.c.gcov envmodules.gcda envmodules.gcno
 
 distclean: clean
@@ -99,4 +104,5 @@ $(V).SILENT: envmodules.o libtclenvmodules@TCL_SHLIB_SUFFIX@ \
 	libtestutil-closedir@SHLIB_SUFFIX@ libtestutil-getpwuid@SHLIB_SUFFIX@ \
 	libtestutil-getgroups@SHLIB_SUFFIX@ libtestutil-0getgroups@SHLIB_SUFFIX@ \
 	libtestutil-dupgetgroups@SHLIB_SUFFIX@ libtestutil-getgrgid@SHLIB_SUFFIX@ \
-	libtestutil-time@SHLIB_SUFFIX@ libtestutil-mktime@SHLIB_SUFFIX@
+	libtestutil-time@SHLIB_SUFFIX@ libtestutil-mktime@SHLIB_SUFFIX@\
+	libtestutil-sysconf@SHLIB_SUFFIX@

--- a/lib/envmodules.c
+++ b/lib/envmodules.c
@@ -1,7 +1,7 @@
 /*************************************************************************
  *
  * ENVMODULES.C, Modules Tcl extension library
- * Copyright (C) 2018-2021 Xavier Delaruelle
+ * Copyright (C) 2018-2022 Xavier Delaruelle
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -352,7 +352,15 @@ Envmodules_InitStateUsergroupsObjCmd(
 
    /* Get actually configured number of groups */
 #if defined(HAVE_SYSCONF) && defined(_SC_NGROUPS_MAX)
-   maxgroups = sysconf(_SC_NGROUPS_MAX);
+   errno = 0;
+   // just -1 means 'no limit' so errno must checked as well
+   if ((maxgroups = sysconf(_SC_NGROUPS_MAX)) == -1 && errno != 0) {
+      Tcl_SetErrno(errno);
+      Tcl_SetObjResult(interp,
+         Tcl_ObjPrintf("couldn't get NGROUPS_MAX variable: %s",
+         Tcl_PosixError(interp)));
+      return TCL_ERROR;
+   }
 #else
 #  if defined(NGROUPS_MAX)
    maxgroups = NGROUPS_MAX;

--- a/lib/testutil-sysconf.c
+++ b/lib/testutil-sysconf.c
@@ -1,0 +1,30 @@
+/*************************************************************************
+ *
+ * TESTUTIL-SYSCONF.C, Superseded sysconf function for test purpose
+ * Copyright (C) 2020-2022 Xavier Delaruelle
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ ************************************************************************/
+
+#include <unistd.h>
+#include <errno.h>
+
+long sysconf(int name)
+{
+   errno = 1;
+   return -1;
+}
+
+/* vim:set tabstop=3 shiftwidth=3 expandtab autoindent: */

--- a/testsuite/example/siteconfig.tcl-1
+++ b/testsuite/example/siteconfig.tcl-1
@@ -176,6 +176,13 @@ if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_TCLEXTLIBFAILEDGETGRGID)]} {
     }
 }
 
+# test tcl ext lib procedures against a failed sysconf call
+if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_TCLEXTLIBFAILEDSYSCONF)]} {
+    if {[catch {[initStateUsergroups]} errMsg]} {
+        reportError $errMsg
+    }
+}
+
 # test tcl ext lib procedures against a failed time call
 if {[info exists env(TESTSUITE_ENABLE_SITECONFIG_TCLEXTLIBFAILEDTIME)]} {
     if {[catch {[initStateClockSeconds]} errMsg]} {

--- a/testsuite/modules.00-init/005-init_ts.exp
+++ b/testsuite/modules.00-init/005-init_ts.exp
@@ -627,6 +627,7 @@ if {$install_libtclenvmodules eq {y}} {
     set getgrgidlib_file lib/libtestutil-getgrgid$install_shlib_suffix
     set timelib_file lib/libtestutil-time$install_shlib_suffix
     set mktimelib_file lib/libtestutil-mktime$install_shlib_suffix
+    set sysconflib_file lib/libtestutil-sysconf$install_shlib_suffix
 }
 
 # check file permission capabilities

--- a/testsuite/modules.00-init/120-siteconfig.exp
+++ b/testsuite/modules.00-init/120-siteconfig.exp
@@ -536,6 +536,21 @@ if {[info exists getgrgidlib_file]} {
     send_user "\tSkip tcl ext lib erroneous procedure calls as ext lib is not available\n"
 }
 
+# test tcl ext lib procedures against a failed sysconf call
+if {[info exists sysconflib_file]} {
+    setenv_var TESTSUITE_ENABLE_SITECONFIG_TCLEXTLIBFAILEDSYSCONF 1
+    setenv_var LD_PRELOAD $sysconflib_file
+    set ans [list]
+    lappend ans "$error_msgs: couldn't get NGROUPS_MAX variable: .*"
+    lappend ans $vers_reportre
+    testouterr_cmd_re sh -V OK [join $ans \n]
+
+    unsetenv_var TESTSUITE_ENABLE_SITECONFIG_TCLEXTLIBFAILEDSYSCONF
+    unsetenv_var LD_PRELOAD
+} elseif {$verbose > 0} {
+    send_user "\tSkip tcl ext lib erroneous procedure calls as ext lib is not available\n"
+}
+
 # test tcl ext lib procedures against a failed time call
 if {[info exists timelib_file]} {
     setenv_var TESTSUITE_ENABLE_SITECONFIG_TCLEXTLIBFAILEDTIME 1


### PR DESCRIPTION
`sysconf` may fail to obtain the value of the `NGROUPS_MAX` variable.  In
such case, it returns -1 and sets `errno` to indicate the error.

Let's handle this situation as the size argument of `ckalloc` is an
`unsigned int` so the size of the allocated memory would be `UINT_MAX` instead.
Subsequently, `getgroups` would fail with `EINVAL` as `maxgroupsize` is non-zero
but less than the number of GIDs that would have been returned.

Note that if `sysconf` returns -1 and leaves `errno` intact, the given
variable has no limit.  However, that does not seem to be the case on
any reasonable operating system [1].

Found by Coverity.

Resolves:
```
modules-5.0.1/lib/envmodules.c:355: negative_return_fn: Function "sysconf(_SC_NGROUPS_MAX)" returns a negative number.
modules-5.0.1/lib/envmodules.c:355: assign: Assigning: "maxgroups" = "sysconf(_SC_NGROUPS_MAX)".
modules-5.0.1/lib/envmodules.c:368: negative_returns: "maxgroups" is passed to a parameter that cannot be negative.
  366|
  367|   #if defined (HAVE_GETGROUPS)
  368|->    if ((ngroups = getgroups(maxgroups, groups)) == -1) {
  369|         Tcl_SetErrno(errno);
  370|         Tcl_SetObjResult(interp,
```
[1] https://www.j3e.de/ngroups.html