### PR TITLE
Fix ShellCheck reports - Part 1

### DIFF
--- a/configure
+++ b/configure
@@ -949,7 +949,7 @@ if [ -n "$pager" ]; then
    pager=$reqpath
 fi
 # adapt pager program settings dependings of specified args
-if [ $defpageropts -eq 1 -a "${pager##*/}" != 'less' ]; then
+if [ $defpageropts -eq 1 ] && [ "${pager##*/}" != 'less' ]; then
     pageropts=''
     echo_warning "As chosen pager is not \`less', default pager options are cleared"
 fi
@@ -1036,7 +1036,7 @@ fi
 [ -z "$modulefilesdir" ] && modulefilesdir=$prefix/modulefiles
 [ -z "$moduleshome" ] && moduleshome=$prefix
 # default modulepath based on MODULE_VERSION if versioning enabled
-[ -z "$modulepath" -a "$versioning" = 'y' ] && modulepath=${modulefilesdir/#$prefix/$baseprefix\/\$MODULE_VERSION}
+[ -z "$modulepath" ] && [ "$versioning" = 'y' ] && modulepath=${modulefilesdir/#$prefix/$baseprefix\/\$MODULE_VERSION}
 [ -z "$modulepath" ] && modulepath=$modulefilesdir
 
 # define libdir64 and libdir32 based on libdir if multilib support enabled
@@ -1052,11 +1052,11 @@ if [ "$multilibsupport" = 'y' ]; then
 fi
 
 # check feature requirements are met
-if [ "$setmodulespath" = 'y' -a -n "$loadedmodules" ]; then
+if [ "$setmodulespath" = 'y' ] && [ -n "$loadedmodules" ]; then
    featmesg="As \`setmodulespath' is enabled beware that \`loadedmodules' may be ignored by init scripts"
    echo_warning "$featmesg"
 fi
-if [ -n "$loadedmodules" -a -z "$modulepath" ]; then
+if [ -n "$loadedmodules" ] && [ -z "$modulepath" ]; then
    featmesg="A value is set for \`loadedmodules' whereas \`modulepath' is not defined"
    echo_warning "$featmesg"
 fi

--- a/configure
+++ b/configure
@@ -837,7 +837,7 @@ for arg in "$@"; do
       echo_error "Unrecognized option \`$arg'" tryhelp;;
    *=*)
       echo -e "Export \`$arg' in environment" ;
-      export "$arg" ;;
+      export "${arg?}" ;;
    *)
       # type of system to build the program for (not needed here but useful
       # for true autoconf configure script below

--- a/configure
+++ b/configure
@@ -40,7 +40,7 @@ windowssupport nearlyforbiddendays implicitrequirement tagabbrev \
 tagcolorname mcookieversioncheck availoutput availterseoutput listoutput \
 listterseoutput editor variantshortcut bashcompletiondir fishcompletiondir \
 zshcompletiondir tcllinter tcllinteropts nagelfardatadir nagelfaraddons"
-libarglist=
+libarglist=()
 
 # flags to know if argument has been specified on command-line
 defmodulespath=1
@@ -152,7 +152,7 @@ sgr() {
    else
       local out=$msg
    fi
-   echo $out
+   echo "$out"
 }
 
 # print message on stderr then exit
@@ -471,9 +471,9 @@ check_requirement() {
          else
             cmdsearch="command -v $cmd"
          fi
-         reqpath=$(eval $cmdsearch)
+         reqpath=$(eval "$cmdsearch")
          if [ -n "$reqpath" ]; then
-            echo $reqpath
+            echo "$reqpath"
             break
          else
             echo "not found"
@@ -527,12 +527,12 @@ get_package_value() {
 for arg in "$@"; do
    # set argument value defined with "--arg val" form
    if [ -n "${nextargisval+x}" ]; then
-      declare $nextargisval=$arg
+      declare "$nextargisval"="$arg"
       unset nextargisval
       continue
    # set lib argument value defined with "--arg val" form
    elif [ -n "${nextargislibarg+x}" ]; then
-      libarglist+="$arg " ;
+      libarglist+=("$arg");
       unset nextargislibarg
       continue
    # current arg should be skipped
@@ -797,7 +797,7 @@ for arg in "$@"; do
    --with-tcl-linter-opts=*|--without-tcl-linter-opts)
       tcllinteropts=$(get_package_value "$arg") ;;
    --with-tcl=*|--without-tcl|--with-tclinclude=*|--without-tclinclude)
-      libarglist+="$arg " ;;
+      libarglist+=("$arg") ;;
    --with-python=*|--without-python)
       pythonbin=$(get_package_value "$arg") ;;
    --with-module-path=*)
@@ -808,12 +808,12 @@ for arg in "$@"; do
       ;;
    --build|--host|--target)
       # pass argument supported by lib to its ./configure script
-      libarglist+="$arg " ;
+      libarglist+=("$arg") ;
       # and set next arg should also be send to lib script
       nextargislibarg=y ;;
    --build=*|--host=*|--target=*)
       # pass argument supported by lib to its ./configure script
-      libarglist+="$arg " ;;
+      libarglist+=("$arg") ;;
    --program-prefix|--program-suffix|--program-transform-name|--exec-prefix|\
    --sbindir|--sysconfdir|--datadir|--includedir|--localstatedir|\
    --sharedstatedir|--infodir|--runstatedir|--oldincludedir|--localedir|\
@@ -837,11 +837,11 @@ for arg in "$@"; do
       echo_error "Unrecognized option \`$arg'" tryhelp;;
    *=*)
       echo -e "Export \`$arg' in environment" ;
-      export $arg ;;
+      export "$arg" ;;
    *)
       # type of system to build the program for (not needed here but useful
       # for true autoconf configure script below
-      libarglist+="$arg " ;;
+      libarglist+=("$arg") ;;
    esac
 done
 
@@ -902,7 +902,7 @@ fi
 # get tclsh location from standard PATHs or /usr/local/bin
 # or validate location passed as argument
 if [ -n "$tclshbin" ]; then
-   check_requirement $tclshbin '' "PATH=$binsearchpath"
+   check_requirement "$tclshbin" '' "PATH=$binsearchpath"
 else
    # also check version-specific names in case no generic tclsh binary exists
    check_requirement $TCLSH '' "PATH=$binsearchpath" 'tclsh8.6' 'tclsh8.5' 'tclsh8.4'
@@ -919,7 +919,7 @@ else
 fi
 # only look at --with-python specification if set
 if [ -n "$pythonbin" ]; then
-   check_requirement $pythonbin "$missmsg" "PATH=$binsearchpath"
+   check_requirement "$pythonbin" "$missmsg" "PATH=$binsearchpath"
 else
    check_requirement $PYTHON "$missmsg" "PATH=$binsearchpath" 'python3' 'python2'
 fi
@@ -946,7 +946,7 @@ BASENAME=$reqpath
 # get pager program location from standard PATHs or /usr/local/bin
 # or validate location passed as argument
 if [ -n "$pager" ]; then
-   check_requirement $pager '' "PATH=$binsearchpath"
+   check_requirement "$pager" '' "PATH=$binsearchpath"
    pager=$reqpath
 fi
 # adapt pager program settings dependings of specified args
@@ -956,7 +956,7 @@ if [ $defpageropts -eq 1 ] && [ "${pager##*/}" != 'less' ]; then
 fi
 
 if [ -n "$tcllinter" ]; then
-   check_requirement $tcllinter "$tcllinter could not be found" "PATH=$binsearchpath"
+   check_requirement "$tcllinter" "$tcllinter could not be found" "PATH=$binsearchpath"
    if [ -n "$reqpath" ]; then
       tcllinter=$reqpath
    fi
@@ -964,12 +964,13 @@ fi
 
 # fetch modules version from version.inc.in file (which may be raw data to
 # refine or exact values if dist has been built by `git archive`)
-if [ -r ${progdir}/version.inc.in ]; then
-  release=$(sed -n '/^MODULES_RELEASE/{s/.*= //p;q;}' ${progdir}/version.inc.in)
+if [ -r "${progdir}/version.inc.in" ]; then
+  release=$(sed -n '/^MODULES_RELEASE/{s/.*= //p;q;}' \
+     "${progdir}/version.inc.in")
   build_hash=$(sed -n '/^MODULES_BUILD_HASH/{s/.*= //p;q;}' \
-     ${progdir}/version.inc.in)
+     "${progdir}/version.inc.in")
   build_refs=$(sed -n '/^MODULES_BUILD_REFS/{s/.*= //p;q;}' \
-     ${progdir}/version.inc.in)
+     "${progdir}/version.inc.in")
   build_refs=${build_refs//,}
   build_refs=${build_refs//origin\/}
 else
@@ -1084,9 +1085,9 @@ done
 # configure extension library sources
 if [ "$libtclenvmodules" = 'y' ]; then
    echo "--- configuring extension library sources --------"
-   echo "libarglist = $libarglist"
+   echo "libarglist = ${libarglist[*]}"
    pushd lib
-   ./configure $libarglist || exit 1
+   ./configure "${libarglist[@]}" || exit 1
    popd
    echo "--------------------------------------------------"
 fi
@@ -1100,7 +1101,7 @@ for target in ${targetlist}; do
       extra_regexp=('-e' 's|\$|\$\$|g')
    fi
    echo "creating $target"
-   sed "${translation_regexp[@]}" "${extra_regexp[@]}" ${target}.in >$target
+   sed "${translation_regexp[@]}" "${extra_regexp[@]}" "${target}.in" >"$target"
 done
 
 exit 0

--- a/configure
+++ b/configure
@@ -160,7 +160,8 @@ echo_error() {
    local firstln=1
    while [ $# -gt 0 ]; do
       if [ $firstln -eq 1 ]; then
-         local msg="$(sgr 2 31 ERROR): $1"
+         local msg
+         msg="$(sgr 2 31 ERROR): $1"
          firstln=0
       elif [ "$1" = 'tryhelp' ]; then
          msg="${msg}\n  Try \`$progpath --help' for more information"

--- a/doc/example/compiler-etc-dependencies/example-sessions/bar-defaults.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/bar-defaults.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 case $TMP_STRATEGY in
    modulepath)
-	do_cmd module load $GCCGNU/9.1.0
+	do_cmd module load "$GCCGNU/9.1.0"
 	;;
 esac
 do_cmd module load bar
@@ -29,7 +29,7 @@ fi
 do_cmd module purge
 case $TMP_STRATEGY in
    modulepath)
-	do_cmd module load $GCCGNU/8.2.0
+	do_cmd module load "$GCCGNU/8.2.0"
 	;;
 esac
 do_cmd module load bar/4.7

--- a/doc/example/compiler-etc-dependencies/example-sessions/bar-loads.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/bar-loads.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
-do_cmd module load $GCCGNU/9.1.0
+do_cmd module load "$GCCGNU/9.1.0"
 case $TMP_STRATEGY in
    flavours|homebrewed)
 	do_cmd module load simd/avx2
@@ -22,7 +22,7 @@ do_cmd bar
 do_cmd module unload bar
 case $TMP_STRATEGY in
    flavours|homebrewed)
-	do_cmd module switch $AUTOFLAG simd simd/avx
+	do_cmd module switch "$AUTOFLAG" simd simd/avx
 	do_cmd module load bar/5.4
 	;;
    modulerc)
@@ -39,7 +39,7 @@ do_cmd bar
 do_cmd module unload bar
 case $TMP_STRATEGY in
    flavours|homebrewed)
-	do_cmd module switch $AUTOFLAG simd simd/sse4.1
+	do_cmd module switch "$AUTOFLAG" simd simd/sse4.1
 	do_cmd module load bar/5.4
 	;;
    modulerc)

--- a/doc/example/compiler-etc-dependencies/example-sessions/bar-switch.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/bar-switch.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
-do_cmd module load $GCCGNU/9.1.0
+do_cmd module load "$GCCGNU/9.1.0"
 case $TMP_STRATEGY in
    flavours|homebrewed)
 	do_cmd module load simd/avx
@@ -20,13 +20,13 @@ do_cmd module list
 do_cmd bar
 case $TMP_STRATEGY in
    flavours|homebrewed)
-	do_cmd module switch $AUTOFLAG simd simd/avx2
+	do_cmd module switch "$AUTOFLAG" simd simd/avx2
 	;;
    modulerc)
-	do_cmd module switch $AUTOFLAG bar bar/avx2
+	do_cmd module switch "$AUTOFLAG" bar bar/avx2
 	;;
    modulepath)
-	do_cmd module switch $AUTOFLAG bar bar/5.4/avx2
+	do_cmd module switch "$AUTOFLAG" bar bar/5.4/avx2
 	;;
 esac
 do_cmd module list

--- a/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 #
 # This should be sourced from the other scripts
 

--- a/doc/example/compiler-etc-dependencies/example-sessions/foo-avail1.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/foo-avail1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 case $TMP_STRATEGY in

--- a/doc/example/compiler-etc-dependencies/example-sessions/foo-avail2.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/foo-avail2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 case $TMP_STRATEGY in

--- a/doc/example/compiler-etc-dependencies/example-sessions/foo-defaults.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/foo-defaults.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 case $TMP_STRATEGY in
    modulepath)
 	do_cmd module load foo
-	do_cmd module load $GCCGNU/8.2.0
+	do_cmd module load "$GCCGNU/8.2.0"
 	;;
 esac
 do_cmd module load foo
@@ -31,7 +31,7 @@ fi
 do_cmd module purge
 case $TMP_STRATEGY in
    modulepath)
-	do_cmd module load $GCCGNU/8.2.0
+	do_cmd module load "$GCCGNU/8.2.0"
 	do_cmd module load openmpi
 	do_cmd module load foo
 	do_cmd module list

--- a/doc/example/compiler-etc-dependencies/example-sessions/foo-loads.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/foo-loads.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 do_cmd module load pgi/19.4
@@ -15,7 +15,7 @@ do_cmd foo
 
 do_cmd module unload foo
 do_cmd module unload openmpi
-do_cmd module switch $AUTOFLAG pgi intel/2019
+do_cmd module switch "$AUTOFLAG" pgi intel/2019
 do_cmd module load foo/2.4
 do_cmd module list
 do_cmd foo
@@ -32,19 +32,19 @@ esac
 do_cmd module list
 do_cmd foo
 do_cmd module unload foo
-do_cmd module switch $AUTOFLAG intelmpi mvapich/2.3.1
+do_cmd module switch "$AUTOFLAG" intelmpi mvapich/2.3.1
 do_cmd module load foo/2.4
 do_cmd module list
 do_cmd foo
 do_cmd module unload foo
-do_cmd module switch $AUTOFLAG mvapich openmpi/4.0
+do_cmd module switch "$AUTOFLAG" mvapich openmpi/4.0
 do_cmd module load foo/2.4
 do_cmd module list
 do_cmd foo
 
 do_cmd module unload foo
 do_cmd module unload openmpi
-do_cmd module switch $AUTOFLAG intel/2019 $GCCGNU/9.1.0
+do_cmd module switch "$AUTOFLAG" intel/2019 "$GCCGNU/9.1.0"
 do_cmd module load foo/2.4
 do_cmd module list
 do_cmd foo
@@ -54,7 +54,7 @@ do_cmd module load foo/2.4
 do_cmd module list
 do_cmd foo
 do_cmd module unload foo
-do_cmd module switch $AUTOFLAG mvapich openmpi/4.0
+do_cmd module switch "$AUTOFLAG" mvapich openmpi/4.0
 do_cmd module load foo/2.4
 do_cmd module list
 do_cmd foo

--- a/doc/example/compiler-etc-dependencies/example-sessions/foo-switch.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/foo-switch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 do_cmd module load pgi/18.4
@@ -8,7 +8,7 @@ do_cmd module load openmpi/3.1
 do_cmd module load foo/1.1
 do_cmd module list
 do_cmd foo
-do_cmd module switch $AUTOFLAG pgi intel/2018
+do_cmd module switch "$AUTOFLAG" pgi intel/2018
 do_cmd module list
 do_cmd foo
 do_cmd mpirun
@@ -17,6 +17,6 @@ do_cmd module load intel/2019
 do_cmd module load foo
 do_cmd module list
 do_cmd foo
-do_cmd module load $AUTOFLAG openmpi
+do_cmd module load "$AUTOFLAG" openmpi
 do_cmd module list
 do_cmd foo

--- a/doc/example/compiler-etc-dependencies/example-sessions/modavail.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/modavail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module avail
 case $TMP_STRATEGY in
@@ -8,7 +8,7 @@ case $TMP_STRATEGY in
 	do_cmd module avail mvapich
 	;;
    modulepath)
-	do_cmd module load $GCCGNU/9.1.0
+	do_cmd module load "$GCCGNU/9.1.0"
 	do_cmd module avail
 	do_cmd module load openmpi/4.0
 	do_cmd module avail

--- a/doc/example/compiler-etc-dependencies/example-sessions/modversion.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/modversion.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module --version
 do_cmd echo "MODULEPATH=$MODULEPATH"

--- a/doc/example/compiler-etc-dependencies/example-sessions/ompi-defaults.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/ompi-defaults.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 do_cmd module load openmpi/3.1
@@ -21,7 +21,7 @@ if [ $err -eq 0 ]; then
 	esac
 fi
 do_cmd module purge
-do_cmd module load $GCCGNU/8.2.0
+do_cmd module load "$GCCGNU/8.2.0"
 do_cmd module load openmpi
 err=$?
 do_cmd module list

--- a/doc/example/compiler-etc-dependencies/example-sessions/ompi-loads1.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/ompi-loads1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 do_cmd module load pgi/19.4
@@ -9,18 +9,18 @@ do_cmd module list
 do_cmd mpirun
 
 do_cmd module unload openmpi
-do_cmd module switch $AUTOFLAG pgi intel/2019
+do_cmd module switch "$AUTOFLAG" pgi intel/2019
 do_cmd module load openmpi/4.0
 do_cmd module list
 do_cmd mpirun
 
 do_cmd module unload openmpi
-do_cmd module switch $AUTOFLAG intel $GCCGNU/9.1.0
+do_cmd module switch "$AUTOFLAG" intel "$GCCGNU/9.1.0"
 do_cmd module load openmpi/4.0
 do_cmd mpirun
 
 do_cmd module unload openmpi
-do_cmd module switch $AUTOFLAG $GCCGNU $GCCGNU/8.2.0
+do_cmd module switch "$AUTOFLAG" "$GCCGNU" "$GCCGNU/8.2.0"
 do_cmd module load openmpi/4.0
 do_cmd module list
 

--- a/doc/example/compiler-etc-dependencies/example-sessions/ompi-switch.sh
+++ b/doc/example/compiler-etc-dependencies/example-sessions/ompi-switch.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-source $MOD_GIT_ROOTDIR/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
+source "$MOD_GIT_ROOTDIR"/doc/example/compiler-etc-dependencies/example-sessions/common_code.sh
 
 do_cmd module purge
 do_cmd module load pgi/19.4
 do_cmd module load openmpi
 do_cmd module list
 do_cmd mpirun
-do_cmd module switch $AUTOFLAG pgi intel/2019
+do_cmd module switch "$AUTOFLAG" pgi intel/2019
 do_cmd module list
 do_cmd mpirun
 case $TMP_STRATEGY in
@@ -16,7 +16,7 @@ case $TMP_STRATEGY in
 	case $TMP_MODVERSION in
            3.*)
 		#Only do it on 3.x, as switch fails on 4.x
-		do_cmd module switch $AUTOFLAG intel intel/2018
+		do_cmd module switch "$AUTOFLAG" intel intel/2018
 		do_cmd module list
 		do_cmd mpirun
 		;;
@@ -27,7 +27,7 @@ case $TMP_STRATEGY in
 	case $TMP_MODVERSION in
            4.*)
 		#Only do it on 4.x, as switch fails on 3.x
-		do_cmd module switch $AUTOFLAG intel intel/2018
+		do_cmd module switch "$AUTOFLAG" intel intel/2018
 		do_cmd module list
 		do_cmd mpirun
 		;;

--- a/doc/example/compiler-etc-dependencies/example-sessions/ompi-switch.sh.m431
+++ b/doc/example/compiler-etc-dependencies/example-sessions/ompi-switch.sh.m431
@@ -2,7 +2,7 @@
 
 do_cmd()
 {	cmd="$@"
-	echo $MPS1 $cmd
+	echo "$MPS1" $cmd
 	$cmd
 }
 

--- a/doc/example/source-script-in-modulefile/bar-2.1/bar-setup.sh
+++ b/doc/example/source-script-in-modulefile/bar-2.1/bar-setup.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-export PATH=$(dirname "${BASH_SOURCE[0]}")/bin:$PATH
+PATH=$(dirname "${BASH_SOURCE[0]}")/bin:$PATH
+export PATH
 bar() {
     barbin -q -l
 }

--- a/doc/example/source-script-in-modulefile/bar-2.1/bar-setup.sh
+++ b/doc/example/source-script-in-modulefile/bar-2.1/bar-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export PATH=$(dirname $BASH_SOURCE)/bin:$PATH
+export PATH=$(dirname "${BASH_SOURCE[0]}")/bin:$PATH
 bar() {
     barbin -q -l
 }

--- a/doc/example/source-script-in-modulefile/foo-1.2/foo-setup.sh
+++ b/doc/example/source-script-in-modulefile/foo-1.2/foo-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 export FOOENV="$1"
-export PATH=$(dirname "${BASH_SOURCE[0]}")/bin:$PATH
+PATH=$(dirname "${BASH_SOURCE[0]}")/bin:$PATH
+export PATH
 alias foo='foobin -q -l'

--- a/doc/example/source-script-in-modulefile/foo-1.2/foo-setup.sh
+++ b/doc/example/source-script-in-modulefile/foo-1.2/foo-setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export FOOENV="$1"
-export PATH=$(dirname $BASH_SOURCE)/bin:$PATH                                                             
+export PATH=$(dirname "${BASH_SOURCE[0]}")/bin:$PATH
 alias foo='foobin -q -l'

--- a/init/bash.in
+++ b/init/bash.in
@@ -25,11 +25,11 @@ fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-}; do
    if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" ] && [ "${_mlv}" = "${_mlv#[0-9]}" ]; then
-      if [ -n "$(eval 'echo ${'$_mlv'+x}')" ]; then
-         _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'$_mlv'}')' ";
+      if [ -n "$(eval 'echo ${'"$_mlv"'+x}')" ]; then
+         _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'"$_mlv"'}')' ";
       fi;
       _mlrv="MODULES_RUNENV_${_mlv}";
-      _mlre="${_mlre:-}${_mlv}='$(eval 'echo ${'$_mlrv':-}')' ";
+      _mlre="${_mlre:-}${_mlv}='$(eval 'echo ${'"$_mlrv"':-}')' ";
    fi;
 done;
 if [ -n "${_mlre:-}" ]; then
@@ -38,6 +38,7 @@ fi;
 
 # define module command and surrounding initial environment (default value
 # for MODULESHOME, MODULEPATH, LOADEDMODULES and parse of init config files)
+# shellcheck disable=2086 # word splitting expected on _mlre
 eval "$(${_mlre:-}@TCLSH@ '@libexecdir@/modulecmd.tcl' bash autoinit)"
 
 # clean temp variables used to setup quarantine
@@ -51,7 +52,7 @@ unset _mlre _mlv _mlrv
 
 # restore shell debugging options if disabled
 if [ -n "${_mlshdbg:-}" ]; then
-   set -$_mlshdbg;
+   set -"$_mlshdbg";
    unset _mlshdbg;
 fi;
 

--- a/init/bash.in
+++ b/init/bash.in
@@ -52,3 +52,5 @@ if [ -n "${_mlshdbg:-}" ]; then
    set -$_mlshdbg;
    unset _mlshdbg;
 fi;
+
+# vim:set tabstop=3 shiftwidth=3 expandtab autoindent syntax=sh:

--- a/init/bash.in
+++ b/init/bash.in
@@ -24,7 +24,7 @@ if [ -n "${IFS+x}" ]; then
 fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-}; do
-   if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" -a "${_mlv}" = "${_mlv#[0-9]}" ]; then
+   if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" ] && [ "${_mlv}" = "${_mlv#[0-9]}" ]; then
       if [ -n "$(eval 'echo ${'$_mlv'+x}')" ]; then
          _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'$_mlv'}')' ";
       fi;

--- a/init/bash.in
+++ b/init/bash.in
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 unset _mlshdbg;
 # disable shell debugging for the run of this init file
 if [ "${MODULES_SILENT_SHELL_DEBUG:-0}" = '1' ]; then

--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -20,7 +20,7 @@ _module_avail() {
     local cur="${1:-}"
     # skip avail call if word currently being completed is an option keyword
     if [ -z "$cur" ] || [ "${cur:0:1}" != '-' ]; then
-        module avail --color=never -s -t -S --no-indepth -o '' $cur 2>&1
+        module avail --color=never -s -t -S --no-indepth -o '' "$cur" 2>&1
     fi
 }
 
@@ -32,7 +32,7 @@ _module_savelist() {
 }
 
 _module_not_yet_loaded() {
-    _module_avail ${1:-} | sort | @SED_ERE@ "\%^(${LOADEDMODULES//:/|})$%d"
+    _module_avail "${1:-}" | sort | @SED_ERE@ "\%^(${LOADEDMODULES//:/|})$%d"
 }
 
 _module_long_arg_list() {
@@ -40,13 +40,13 @@ _module_long_arg_list() {
 
     if [[ ${COMP_WORDS[COMP_CWORD-2]} == sw* ]]
     then
-        _module_comgen_words_and_files "$(_module_not_yet_loaded $cur)" "$cur"
+        _module_comgen_words_and_files "$(_module_not_yet_loaded "$cur")" "$cur"
         return
     fi
     for ((i = COMP_CWORD - 1; i > 0; i--))
         do case ${COMP_WORDS[$i]} in
         add|load)
-            _module_comgen_words_and_files "$(_module_not_yet_loaded $cur)" "$cur"
+            _module_comgen_words_and_files "$(_module_not_yet_loaded "$cur")" "$cur"
             break;;
         rm|del|remove|unload|switch|swap)
             COMPREPLY=( $(IFS=: compgen -W "${LOADEDMODULES}" -- "$cur") )
@@ -62,9 +62,9 @@ _module() {
 
     case "$prev" in
     add|add-any|load|load-any|try-add|try-load)
-                    _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded $cur)" "$cur";;
-    avail)          _module_comgen_words_and_files "@comp_avail_opts@ $(_module_avail $cur)" "$cur";;
-    edit)           _module_comgen_words_and_files "$(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded "$cur")" "$cur";;
+    avail)          _module_comgen_words_and_files "@comp_avail_opts@ $(_module_avail "$cur")" "$cur";;
+    edit)           _module_comgen_words_and_files "$(_module_avail "$cur")" "$cur";;
     aliases)  COMPREPLY=( $(compgen -W "@comp_aliases_opts@" -- "$cur") );;
     list|savelist)  COMPREPLY=( $(compgen -W "@comp_list_opts@" -- "$cur") );;
     clear)  COMPREPLY=( $(compgen -W "@comp_clear_opts@" -- "$cur") );;
@@ -76,15 +76,15 @@ _module() {
     unuse|is-used)  COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "$cur") );;
     use|-a|--append)   ;;               # let readline handle the completion
     display|help|show|test|path|paths|is-loaded|info-loaded)
-                    _module_comgen_words_and_files "@comp_mfile_opts@ $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_mfile_opts@ $(_module_avail "$cur")" "$cur";;
     is-avail)
-                    _module_comgen_words_and_files "@comp_isavail_opts@ $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_isavail_opts@ $(_module_avail "$cur")" "$cur";;
     lint)
-                    _module_comgen_words_and_files "@comp_lint_opts@ $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_lint_opts@ $(_module_avail "$cur")" "$cur";;
     mod-to-sh)
-                    _module_comgen_words_and_files "@comp_modtosh_opts@ $(_module_not_yet_loaded $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_modtosh_opts@ $(_module_not_yet_loaded "$cur")" "$cur";;
     whatis)
-                    _module_comgen_words_and_files "@comp_whatis_opts@ $(_module_avail $cur)" "$cur";;
+                    _module_comgen_words_and_files "@comp_whatis_opts@ $(_module_avail "$cur")" "$cur";;
     apropos|keyword|search)
                     COMPREPLY=( $(compgen -W "@comp_search_opts@" -- "$cur") );;
     config|--reset) COMPREPLY=( $(compgen -W "@comp_config_opts@" -- "$cur") );;
@@ -96,7 +96,7 @@ _module() {
                     COMPREPLY=( $(compgen -W "@comp_rm_path_opts@" -- "$cur") );;
     initadd|initclear|initlist|initprepend|initrm)
                     ;;
-    *)  if test $COMP_CWORD -gt 2
+    *)  if test "$COMP_CWORD" -gt 2
         then
             _module_long_arg_list "$cur"
         else
@@ -121,9 +121,9 @@ if $(type -t ml >/dev/null); then
 
         case "$prev" in
         add|add-any|load|load-any|try-add|try-load)
-                        _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded $cur)" "$cur";;
-        avail)          _module_comgen_words_and_files "@comp_avail_opts@ $(_module_avail $cur)" "$cur";;
-        edit)           _module_comgen_words_and_files "$(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded "$cur")" "$cur";;
+        avail)          _module_comgen_words_and_files "@comp_avail_opts@ $(_module_avail "$cur")" "$cur";;
+        edit)           _module_comgen_words_and_files "$(_module_avail "$cur")" "$cur";;
         aliases)  COMPREPLY=( $(compgen -W "@comp_aliases_opts@" -- "$cur") );;
         list|savelist)  COMPREPLY=( $(compgen -W "@comp_list_opts@" -- "$cur") );;
         clear)  COMPREPLY=( $(compgen -W "@comp_clear_opts@" -- "$cur") );;
@@ -135,15 +135,15 @@ if $(type -t ml >/dev/null); then
         unuse|is-used)  COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "$cur") );;
         use|-a|--append)   ;;               # let readline handle the completion
         display|help|show|test|path|paths|is-loaded|info-loaded)
-                        _module_comgen_words_and_files "@comp_mfile_opts@ $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_mfile_opts@ $(_module_avail "$cur")" "$cur";;
         is-avail)
-                        _module_comgen_words_and_files "@comp_isavail_opts@ $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_isavail_opts@ $(_module_avail "$cur")" "$cur";;
         lint)
-                        _module_comgen_words_and_files "@comp_lint_opts@ $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_lint_opts@ $(_module_avail "$cur")" "$cur";;
         mod-to-sh)
-                        _module_comgen_words_and_files "@comp_modtosh_opts@ $(_module_not_yet_loaded $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_modtosh_opts@ $(_module_not_yet_loaded "$cur")" "$cur";;
         whatis)
-                        _module_comgen_words_and_files "@comp_whatis_opts@ $(_module_avail $cur)" "$cur";;
+                        _module_comgen_words_and_files "@comp_whatis_opts@ $(_module_avail "$cur")" "$cur";;
         apropos|keyword|search)
                         COMPREPLY=( $(compgen -W "@comp_search_opts@" -- "$cur") );;
         config|--reset) COMPREPLY=( $(compgen -W "@comp_config_opts@" -- "$cur") );;
@@ -155,7 +155,7 @@ if $(type -t ml >/dev/null); then
                         COMPREPLY=( $(compgen -W "@comp_rm_path_opts@" -- "$cur") );;
         initadd|initclear|initlist|initprepend|initrm)
                         ;;
-        *)  if test $COMP_CWORD -gt 2
+        *)  if test "$COMP_CWORD" -gt 2
             then
                 _module_long_arg_list "$cur"
             else
@@ -170,7 +170,7 @@ if $(type -t ml >/dev/null); then
                             loaded_modules+="-${i} "
                         done
                         COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "@comp_load_opts@ $loaded_modules" -- "$cur") );;
-                *)       _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded $cur)" "$cur"
+                *)       _module_comgen_words_and_files "@comp_load_opts@ $(_module_not_yet_loaded "$cur")" "$cur"
                         COMPREPLY=( "${COMPREPLY[@]}" $(compgen -W "@comp_opts@ @comp_cmds@" -- "$cur") )
                         loaded_modules=""
                         for i in ${LOADEDMODULES//:/ }; do

--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -102,8 +102,8 @@ _module() {
         else
             case "$cur" in
             # The mappings below are optional abbreviations for convenience
-            ls)     COMPREPLY="list";;      # map ls -> list
-            sw*)    COMPREPLY="switch";;
+            ls)     COMPREPLY=( "list" );;      # map ls -> list
+            sw*)    COMPREPLY=( "switch" );;
 
             -*)     COMPREPLY=( $(compgen -W "@comp_opts@" -- "$cur") );;
             *)      COMPREPLY=( $(compgen -W "@comp_opts@ @comp_cmds@" -- "$cur") );;
@@ -161,8 +161,8 @@ if $(type -t ml >/dev/null); then
             else
                 case "$cur" in
                 # The mappings below are optional abbreviations for convenience
-                ls)     COMPREPLY="list";;      # map ls -> list
-                sw*)    COMPREPLY="switch";;
+                ls)     COMPREPLY=( "list" );;      # map ls -> list
+                sw*)    COMPREPLY=( "switch" );;
 
                 -*)     COMPREPLY=( $(compgen -W "@comp_opts@" -- "$cur") )
                         loaded_modules=""

--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -7,7 +7,7 @@ _module_comgen_words_and_files() {
     local setnospace=1
     # do not append space to word completed if it is a directory (ends with /)
     for val in $(compgen -W "$1" -- "$2"); do
-        if [ !$setnospace -a "${val: -1:1}" = '/' ]; then
+        if [ ! $setnospace -a "${val: -1:1}" = '/' ]; then
             # Bash >=4.0 is required for compopt
             type compopt &>/dev/null && compopt -o nospace
             setnospace=0

--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #
 # Bash commandline completion
 #

--- a/init/bash_completion.in
+++ b/init/bash_completion.in
@@ -7,7 +7,7 @@ _module_comgen_words_and_files() {
     local setnospace=1
     # do not append space to word completed if it is a directory (ends with /)
     for val in $(compgen -W "$1" -- "$2"); do
-        if [ ! $setnospace -a "${val: -1:1}" = '/' ]; then
+        if [ ! $setnospace ] && [ "${val: -1:1}" = '/' ]; then
             # Bash >=4.0 is required for compopt
             type compopt &>/dev/null && compopt -o nospace
             setnospace=0
@@ -19,7 +19,7 @@ _module_comgen_words_and_files() {
 _module_avail() {
     local cur="${1:-}"
     # skip avail call if word currently being completed is an option keyword
-    if [ -z "$cur" -o "${cur:0:1}" != '-' ]; then
+    if [ -z "$cur" ] || [ "${cur:0:1}" != '-' ]; then
         module avail --color=never -s -t -S --no-indepth -o '' $cur 2>&1
     fi
 }

--- a/init/ksh.in
+++ b/init/ksh.in
@@ -1,3 +1,5 @@
+# shellcheck shell=ksh
+
 unset _mlshdbg;
 # disable shell debugging for the run of this init file
 if [ "${MODULES_SILENT_SHELL_DEBUG:-0}" = '1' ]; then

--- a/init/ksh.in
+++ b/init/ksh.in
@@ -25,11 +25,11 @@ fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-}; do
    if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" ] && [ "${_mlv}" = "${_mlv#[0-9]}" ]; then
-      if [ -n "$(eval 'echo ${'$_mlv'+x}')" ]; then
-         _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'$_mlv'}')' ";
+      if [ -n "$(eval 'echo ${'"$_mlv"'+x}')" ]; then
+         _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'"$_mlv"'}')' ";
       fi;
       _mlrv="MODULES_RUNENV_${_mlv}";
-      _mlre="${_mlre:-}${_mlv}='$(eval 'echo ${'$_mlrv':-}')' ";
+      _mlre="${_mlre:-}${_mlv}='$(eval 'echo ${'"$_mlrv"':-}')' ";
    fi;
 done;
 if [ -n "${_mlre:-}" ]; then
@@ -38,6 +38,7 @@ fi;
 
 # define module command and surrounding initial environment (default value
 # for MODULESHOME, MODULEPATH, LOADEDMODULES and parse of init config files)
+# shellcheck disable=2086 # word splitting expected on _mlre
 eval "$(${_mlre:-}@TCLSH@ '@libexecdir@/modulecmd.tcl' ksh autoinit)"
 
 # clean temp variables used to setup quarantine
@@ -51,7 +52,7 @@ unset _mlre _mlv _mlrv
 
 # restore shell debugging options if disabled
 if [ -n "${_mlshdbg:-}" ]; then
-   set -$_mlshdbg;
+   set -"$_mlshdbg";
    unset _mlshdbg;
 fi;
 

--- a/init/ksh.in
+++ b/init/ksh.in
@@ -52,3 +52,5 @@ if [ -n "${_mlshdbg:-}" ]; then
    set -$_mlshdbg;
    unset _mlshdbg;
 fi;
+
+# vim:set tabstop=3 shiftwidth=3 expandtab autoindent syntax=sh:

--- a/init/ksh.in
+++ b/init/ksh.in
@@ -24,7 +24,7 @@ if [ -n "${IFS+x}" ]; then
 fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-}; do
-   if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" -a "${_mlv}" = "${_mlv#[0-9]}" ]; then
+   if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" ] && [ "${_mlv}" = "${_mlv#[0-9]}" ]; then
       if [ -n "$(eval 'echo ${'$_mlv'+x}')" ]; then
          _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'$_mlv'}')' ";
       fi;

--- a/init/profile.sh.in
+++ b/init/profile.sh.in
@@ -1,3 +1,5 @@
+# shellcheck shell=sh
+
 # get current shell name by querying shell variables or looking at parent
 # process name
 if [ -n "${BASH:-}" ]; then

--- a/init/profile.sh.in
+++ b/init/profile.sh.in
@@ -7,7 +7,7 @@ if [ -n "${BASH:-}" ]; then
 elif [ -n "${ZSH_NAME:-}" ]; then
    shell=$ZSH_NAME
 else
-   shell=$(@BASENAME@ $(@PS@ -p $$ -ocomm=))
+   shell=$(@BASENAME@ "$(@PS@ -p $$ -ocomm=)")
 fi
 
 if [ -f "@initdir@/$shell" ]; then

--- a/init/sh.in
+++ b/init/sh.in
@@ -25,11 +25,11 @@ fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-}; do
    if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" ] && [ "${_mlv}" = "${_mlv#[0-9]}" ]; then
-      if [ -n "$(eval 'echo ${'$_mlv'+x}')" ]; then
-         _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'$_mlv'}')' ";
+      if [ -n "$(eval 'echo ${'"$_mlv"'+x}')" ]; then
+         _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'"$_mlv"'}')' ";
       fi;
       _mlrv="MODULES_RUNENV_${_mlv}";
-      _mlre="${_mlre:-}${_mlv}='$(eval 'echo ${'$_mlrv':-}')' ";
+      _mlre="${_mlre:-}${_mlv}='$(eval 'echo ${'"$_mlrv"':-}')' ";
    fi;
 done;
 if [ -n "${_mlre:-}" ]; then
@@ -38,6 +38,7 @@ fi;
 
 # define module command and surrounding initial environment (default value
 # for MODULESHOME, MODULEPATH, LOADEDMODULES and parse of init config files)
+# shellcheck disable=2086 # word splitting expected on _mlre
 _mlcode=$(${_mlre:-}@TCLSH@ '@libexecdir@/modulecmd.tcl' sh autoinit)
 _mlret=$?
 
@@ -68,8 +69,8 @@ unset _mlcode _mlret
 
 # restore shell debugging options if disabled
 if [ -n "${_mlshdbg:-}" ]; then
-   set -$_mlshdbg;
+   set -"$_mlshdbg";
    unset _mlshdbg;
 fi;
 
-# vim:set tabstop=3 shiftwidth=3 expandtab autoindent syntax=sh:
+# vim:set tabstop=3 shiftwidth=3 expandtab autoindent syntax=sh :

--- a/init/sh.in
+++ b/init/sh.in
@@ -69,3 +69,5 @@ if [ -n "${_mlshdbg:-}" ]; then
    set -$_mlshdbg;
    unset _mlshdbg;
 fi;
+
+# vim:set tabstop=3 shiftwidth=3 expandtab autoindent syntax=sh:

--- a/init/sh.in
+++ b/init/sh.in
@@ -1,3 +1,5 @@
+# shellcheck shell=sh
+
 unset _mlshdbg;
 # disable shell debugging for the run of this init file
 if [ "${MODULES_SILENT_SHELL_DEBUG:-0}" = '1' ]; then

--- a/init/sh.in
+++ b/init/sh.in
@@ -24,7 +24,7 @@ if [ -n "${IFS+x}" ]; then
 fi;
 IFS=' ';
 for _mlv in ${MODULES_RUN_QUARANTINE:-}; do
-   if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" -a "${_mlv}" = "${_mlv#[0-9]}" ]; then
+   if [ "${_mlv}" = "${_mlv##*[!A-Za-z0-9_]}" ] && [ "${_mlv}" = "${_mlv#[0-9]}" ]; then
       if [ -n "$(eval 'echo ${'$_mlv'+x}')" ]; then
          _mlre="${_mlre:-}__MODULES_QUAR_${_mlv}='$(eval 'echo ${'$_mlv'}')' ";
       fi;

--- a/script/add.modules.in
+++ b/script/add.modules.in
@@ -31,12 +31,12 @@ $0
 	possibly your $HOME/.kshenv (or whatever is
 	specified by the ENV environment variable).
 !
-if [ -r $HOME/.bash_profile ]; then
+if [ -r "$HOME/.bash_profile" ]; then
 	/bin/cat <<!
 	Also your $HOME/.bash_profile will be processed.
 !
 fi
-if [ -r $HOME/.bash_login ]; then
+if [ -r "$HOME/.bash_login" ]; then
 	/bin/cat <<!
 	Also your $HOME/.bash_login will be processed.
 !
@@ -60,7 +60,7 @@ fi
 /bin/echo "Continue on (type n for no - default=yes)?\c"
 read xxx
 
-if [ x$xxx = xn ]
+if [ x"$xxx" = xn ]
 then
 	exit 1
 fi
@@ -70,7 +70,7 @@ cleandot() {
 	/bin/cat <<!
 Cleaning $1
 !
-	mv $1 $3
+	mv "$1" "$3"
 	sed \
 -e "/^[ 	]*if[ 	]*([ 	]*-e[ 	].*\/csh\.modules[ 	]*)[ 	]*then[ 	]*\$/,/^[	]*endif[ 	]*\$/d" \
 -e "/^[ 	]*if[ 	]*\[[ 	]*-[ef][ 	].*\/profile\.modules[ 	]*][ 	]*\$/,/^[ 	]*fi[ 	]*\$/d" \
@@ -81,33 +81,33 @@ Cleaning $1
 -e "/^[ 	]*source[ 	]*.*\/Modules.*\$/d" \
 -e "/^[ 	]*source[ 	]*.*\/csh\.modules[ 	]*/d" \
 -e "/^[ 	]*\.[ 	]*.*\/profile\.modules[ 	]*/d" \
-	$3 > $2
+	"$3" > "$2"
 }
 
 # find if certain of the dot files have load lines already
 findload() {
-	grep "^[ 	]*module[ 	]*load" $1 > /tmp/load.$$
+	grep "^[ 	]*module[ 	]*load" "$1" > /tmp/load.$$
 }
 
 # put common stuff derivatives here $1=.dot_file $2=action $3=shell(csh,sh) $4=skel alternative
 shdot() {
-	if [ -f $1 ]
+	if [ -f "$1" ]
 	then
 		/bin/cat <<!
 
 Processing your $1 (your old one is $1.old)
 !
-		if cleandot $1 /tmp/$1.$$ $1.old
+		if cleandot "$1" "/tmp/$1.$$" "$1.old"
 		then
-			if [ x$2 = xsource ]
+			if [ x"$2" = xsource ]
 			then
 				/bin/cat <<!
-Adding sourcing lines at beginning of $1
+Adding sourcing lines at beginning of "$1"
 !
-				if [ x$3 = xsh ]
+				if [ x"$3" = xsh ]
 				then
-					findload $1.old
-					/bin/cat > $1 <<!
+					findload "$1.old"
+					/bin/cat > "$1" <<!
 if [ -f $ETC/profile.modules ]
 then
 	. $ETC/profile.modules
@@ -115,44 +115,44 @@ then
 !
 				if [ -s /tmp/load.$$ ]
 				then
-					/bin/cat /tmp/load.$$ >> $1
+					/bin/cat /tmp/load.$$ >> "$1"
 				else
-					/bin/cat >> $1 <<!
+					/bin/cat >> "$1" <<!
 	module load null
 !
 				fi
-					/bin/cat >> $1 <<!
+					/bin/cat >> "$1" <<!
 fi
 !
-				elif [ x$3 = xcsh ]
+				elif [ x"$3" = xcsh ]
 				then
-					findload $1.old
-					/bin/cat > $1 <<!
+					findload "$1.old"
+					/bin/cat > "$1" <<!
 if ( -e $ETC/csh.modules ) then
 	source $ETC/csh.modules
 # put your own module loads here
 !
 				if [ -s /tmp/load.$$ ]
 				then
-					/bin/cat /tmp/load.$$ >> $1
+					/bin/cat /tmp/load.$$ >> "$1"
 				else
-					/bin/cat >> $1 <<!
+					/bin/cat >> "$1" <<!
 	module load null
 !
 				fi
-					/bin/cat >> $1 <<!
+					/bin/cat >> "$1" <<!
 endif
 !
 				fi
-				/bin/cat /tmp/$1.$$ >> $1 && /bin/rm /tmp/$1.$$
-			elif [ x$2 = xalias ]
+				/bin/cat "/tmp/$1.$$" >> "$1" && /bin/rm "/tmp/$1.$$"
+			elif [ x"$2" = xalias ]
 			then
 				/bin/cat <<!
 Adding alias or function lines at beginning of $1
 !
-				if [ x$3 = xsh ]
+				if [ x"$3" = xsh ]
 				then
-					/bin/cat > $1 <<!
+					/bin/cat > "$1" <<!
 case "\$0" in
           -sh|sh|*/sh)	modules_shell=sh ;;
        -ksh|ksh|*/ksh)	modules_shell=ksh ;;
@@ -161,9 +161,9 @@ case "\$0" in
 esac
 module() { eval \`@TCLSH@ '@libexecdir@/modulecmd.tcl' \$modules_shell \$*\`; }
 !
-				elif [ x$3 = xcsh ]
+				elif [ x"$3" = xcsh ]
 				then
-					/bin/cat > $1 <<!
+					/bin/cat > "$1" <<!
 if (\$?tcsh) then
         set modules_shell="tcsh"
 else
@@ -172,7 +172,7 @@ endif
 alias module 'eval \`@TCLSH@ "@libexecdir@/modulecmd.tcl" '\$modules_shell '\!*\`'
 !
 				fi
-				/bin/cat /tmp/$1.$$ >> $1 && /bin/rm /tmp/$1.$$
+				/bin/cat "/tmp/$1.$$" >> "$1" && /bin/rm "/tmp/$1.$$"
 			fi
 		else
 			/bin/echo "Had problems with your $1"
@@ -181,13 +181,13 @@ alias module 'eval \`@TCLSH@ "@libexecdir@/modulecmd.tcl" '\$modules_shell '\!*\
 		/bin/cat <<!
 You had no $1 as I see it.  Copying $4 for you.
 !
-		/bin/cp $4 $1
+		/bin/cp "$4" "$1"
 	fi
 	/bin/rm /tmp/load.$$ 2> /dev/null
 }
 
 # process files in $HOME
-cd $HOME
+cd "$HOME"
 if [ -r .bash_profile ]; then
 	shdot .bash_profile source sh $SKEL/.profile
 fi
@@ -196,7 +196,7 @@ if [ -r .bash_login ]; then
 fi
 shdot .profile source sh $SKEL/.profile
 shdot .bashrc alias sh $SKEL/.kshenv
-shdot `basename ${ENV:=.kshenv}` alias sh $SKEL/.kshenv
+shdot `basename "${ENV:=.kshenv}"` alias sh $SKEL/.kshenv
 shdot .login source csh $SKEL/.login
 shdot .cshrc alias csh $SKEL/.cshrc
 

--- a/script/add.modules.in
+++ b/script/add.modules.in
@@ -196,7 +196,7 @@ if [ -r .bash_login ]; then
 fi
 shdot .profile source sh $SKEL/.profile
 shdot .bashrc alias sh $SKEL/.kshenv
-shdot `basename "${ENV:=.kshenv}"` alias sh $SKEL/.kshenv
+shdot "`basename "${ENV:=.kshenv}"`" alias sh $SKEL/.kshenv
 shdot .login source csh $SKEL/.login
 shdot .cshrc alias csh $SKEL/.cshrc
 

--- a/script/commit-msg
+++ b/script/commit-msg
@@ -28,7 +28,7 @@ sgr() {
    if [ -t 2 ]; then
       echo "\033[${code}m${msg}\033[0m"
    else
-      echo $msg
+      echo "$msg"
    fi
 }
 
@@ -47,9 +47,9 @@ echo_hint() {
 # check misspellings in commit message
 command -v aspell >/dev/null
 if [ $? -eq 0 ]; then
-   ASPELL_OPTS='-l en -x --home-dir=. --personal=.aspell.en.pws'
+   ASPELL_OPTS=(-l en -x --home-dir=. --personal=.aspell.en.pws)
    # use sed to extract commit message from full commit details
-   words=$(sed '/^# /Q' "$1" | aspell $ASPELL_OPTS list)
+   words=$(sed '/^# /Q' "$1" | aspell "${ASPELL_OPTS[@]}" list)
    # abort if misspelled words found
    if [ -n "$words" ]; then
       befmsg='# commit message was ---------------- >8 -------------'

--- a/script/envml
+++ b/script/envml
@@ -96,9 +96,9 @@ for arg in "${@}"; do
         else
             for subarg in ${arg//:/ }; do
                 if [ "$kind_of_arg" == 'mod' ]; then
-                    modarglist+=("$(arg_into_modaction ${subarg})")
+                    modarglist+=("$(arg_into_modaction "$subarg")")
                 else
-                    maymodarglist+=("$(arg_into_modaction ${subarg})")
+                    maymodarglist+=("$(arg_into_modaction "$subarg")")
                     maycmdarglist+=("$subarg")
                 fi
             done
@@ -129,7 +129,7 @@ if ! typeset -F module >/dev/null; then
 fi
 
 for arg in "${modarglist[@]}"; do
-    module ${arg}
+    module "$arg"
 done
 
 # now execute the real command with its interpreter

--- a/script/envml
+++ b/script/envml
@@ -133,4 +133,4 @@ for arg in "${modarglist[@]}"; do
 done
 
 # now execute the real command with its interpreter
-exec ${cmdarglist[*]}
+exec "${cmdarglist[@]}"

--- a/script/envml
+++ b/script/envml
@@ -86,7 +86,7 @@ if [ $# -eq 0 -o "$1" == '-h' -o "$1" == '--help' ]; then
 fi
 
 # parse arguments
-for arg in ${@}; do
+for arg in "${@}"; do
     # reach separator, everything after is part of cmd
     if [ "$arg" == '--' ]; then
         kind_of_arg='cmd'

--- a/script/envml
+++ b/script/envml
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # ENVML, setup environment with module then run specified command
-# Copyright (C) 2015-2021 CEA/DAM
+# Copyright (C) 2015-2022 CEA/DAM
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -80,7 +80,7 @@ Examples:
 }
 
 # command help is asked
-if [ $# -eq 0 -o "$1" == '-h' -o "$1" == '--help' ]; then
+if [ $# -eq 0 ] || [ "$1" == '-h' ] || [ "$1" == '--help' ]; then
     echo_usage
     exit 0
 fi

--- a/script/mkroot
+++ b/script/mkroot
@@ -72,9 +72,9 @@ do
 		fi
 		for m in 1 2 3 4 5 6 7 8 n p l
 		do
-			if [ -d ./man/man$m ]; then if [ `ls ./man/man$m|wc -l` -eq 0 ]; then
+			if [ -d ./man/man$m ]; then if [ "`ls ./man/man$m|wc -l`" -eq 0 ]; then
 				rmdir ./man/man$m
-				if [ -d ./man/cat$m ]; then if [ `ls ./man/cat$m|wc -l` -eq 0 ]; then
+				if [ -d ./man/cat$m ]; then if [ "`ls ./man/cat$m|wc -l`" -eq 0 ]; then
 					rmdir ./man/cat$m
 				else
 					echo ./man/cat$m is not empty
@@ -85,7 +85,7 @@ do
 		done
 		for d in bin sbin etc lib include info man
 		do
-			if [ -d ./$d ]; then if [ `ls ./$d|wc -l` -eq 0 ]; then
+			if [ -d ./$d ]; then if [ "`ls ./$d|wc -l`" -eq 0 ]; then
 				rmdir ./$d
 			else
 				echo ./$d is not empty

--- a/script/mkroot
+++ b/script/mkroot
@@ -96,13 +96,13 @@ do
 	-m|-make|--m|--make)
 		for d in bin sbin etc lib include info man
 		do
-			mkdir ./$d ; chmod $PERMS ./$d
+			mkdir ./$d ; chmod "$PERMS" ./$d
 		done
-		touch ./man/whatis ; chmod $PERMS ./man/whatis
+		touch ./man/whatis ; chmod "$PERMS" ./man/whatis
 		for m in 1 2 3 4 5 6 7 8 n p l
 		do
-			mkdir ./man/man$m ; chmod $PERMS ./man/man$m
-			mkdir ./man/cat$m ; chmod $PERMS ./man/cat$m
+			mkdir ./man/man$m ; chmod "$PERMS" ./man/man$m
+			mkdir ./man/cat$m ; chmod "$PERMS" ./man/cat$m
 		done
 		exit
 		;;

--- a/script/mt
+++ b/script/mt
@@ -102,7 +102,7 @@ fi
 if [ $# -gt 0 ]; then
    # build list of test files to run test on
    declare -a testfiles
-   for i in ${setuptestfiles[@]} ${@}; do
+   for i in "${setuptestfiles[@]}" "${@}"; do
       j=${i##*/}
       i=${i%/*}
 

--- a/script/mt
+++ b/script/mt
@@ -109,16 +109,16 @@ if [ $# -gt 0 ]; then
       # add all test files if passed a full section number or a test file
       # from collection section (this section must be run entirely)
       if [ "$j" == "$i" ] || [ "$i" == "61" ]; then
-         testfiles+=(testsuite/$testserie.${i}*/*.exp)
+         testfiles+=(testsuite/"$testserie.${i}"*/*.exp)
       else
-         testfiles+=(testsuite/$testserie.${i}*/{010,999,$j}*.exp)
+         testfiles+=(testsuite"/$testserie.${i}"*/{010,999,$j}*.exp)
       fi
    done
 
    # get file name of selected test files (runtest requires .exp file name)
    declare -a testfnames=()
    for i in "${testfiles[@]}"; do
-      if [ -e $i ]; then
+      if [ -e "$i" ]; then
          fname=${i##*/}
          # build list of unique file names
          if [ ${#testfnames[@]} -eq 0 ]\

--- a/script/pre-commit
+++ b/script/pre-commit
@@ -28,7 +28,7 @@ sgr() {
    if [ -t 2 ]; then
       echo "\033[${code}m${msg}\033[0m"
    else
-      echo $msg
+      echo "$msg"
    fi
 }
 
@@ -55,14 +55,14 @@ fi
 command -v aspell >/dev/null
 if [ $? -eq 0 ]; then
    misspell=0
-   ASPELL_OPTS='-l en -x --home-dir=. --personal=.aspell.en.pws'
+   ASPELL_OPTS=(-l en -x --home-dir=. --personal=.aspell.en.pws)
    for docfile in $(git diff --cached --name-only --diff-filter=d | grep -E\
       '(.rst|.md)$'); do
-      words=$(git diff --cached $docfile | grep '^[+][^+]' | aspell\
-         $ASPELL_OPTS list)
+      words=$(git diff --cached "$docfile" | grep '^[+][^+]' | aspell\
+         "${ASPELL_OPTS[@]}" list)
       if [ -n "$words" ]; then
          # interactively edit file to fix misspellings
-         aspell $ASPELL_OPTS check $docfile </dev/tty >/dev/tty;
+         aspell "${ASPELL_OPTS[@]}" check "$docfile" </dev/tty >/dev/tty;
          misspell=1
       fi
    done

--- a/testsuite/bin/install_test_sh
+++ b/testsuite/bin/install_test_sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #
 # INSTALL_TEST_SH, sh-kind test launcher for install non-reg suite
-# Copyright (C) 2017-2021 Xavier Delaruelle
+# Copyright (C) 2017-2022 Xavier Delaruelle
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,14 +73,14 @@ else
    autoinit=1
 fi
 
-if [ $autoinit -eq 0 -a ! -x "$initfile" ]; then
+if [ $autoinit -eq 0 ] && [ ! -x "$initfile" ]; then
    echo_error "Cannot execute $initfile"
-elif [ $autoinit -ne 0 -a ! -r "$initfile" ]; then
+elif [ $autoinit -ne 0 ] && [ ! -r "$initfile" ]; then
    echo_error "Cannot read $initfile"
 fi
 
 # source module init file if first step of given mode
-if [ "$mode" = 'top' -o "$mode" = 'sub' -o  "$mode" = 'subsub' ]; then
+if [ "$mode" = 'top' ] || [ "$mode" = 'sub' ] || [ "$mode" = 'subsub' ]; then
    if [ $autoinit -eq 0 ]; then
       eval "$("$initfile" $shname autoinit)"
    else

--- a/testsuite/bin/install_test_sh
+++ b/testsuite/bin/install_test_sh
@@ -19,7 +19,7 @@
 ##########################################################################
 
 progpath=$0
-progdir=$(dirname $progpath)
+progdir=$(dirname "$progpath")
 [ -z "$progdir" ] && progdir='.'
 ret=0
 
@@ -43,7 +43,7 @@ shift
 cmdlist=${@}
 
 # get shell kind and options for sublaunch
-shname=$(basename $sh)
+shname=$(basename "$sh")
 if [ "$shname" = 'ksh93' ]; then
    shname='ksh'
 fi
@@ -101,18 +101,18 @@ case "$mode" in
       IFS=';'
       for cmd in ${cmdlist}; do
          unset IFS
-         eval $cmd
+         eval "$cmd"
          ret=$(($ret+$?))
          IFS=';'
       done
       unset IFS
       ;;
    sub|sublaunch)
-      $sh $shopts $progdir/install_test_${shkind} "$initfile" launch $sh "$cmdlist"
+      $sh $shopts $progdir/install_test_${shkind} "$initfile" launch "$sh" "$cmdlist"
       ret=$?
       ;;
    subsub)
-      $sh $shopts $progdir/install_test_${shkind} "$initfile" sublaunch $sh "$cmdlist"
+      $sh $shopts $progdir/install_test_${shkind} "$initfile" sublaunch "$sh" "$cmdlist"
       ret=$?
       ;;
    *)

--- a/testsuite/cmd.exe
+++ b/testsuite/cmd.exe
@@ -1,4 +1,5 @@
 #!/bin/sh
 # fake Windows cmd.exe command execution 
 shift 1
+# shellcheck disable=2048 # word expansion from string expected
 $*

--- a/testsuite/systest
+++ b/testsuite/systest
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ $# -eq 3 ]; then
-    exit $1$2$3
+    exit "$1$2$3"
 else
     exit 123
 fi


### PR DESCRIPTION
This PR is the first one in the series to address all ShellCheck reports in this project.  See the commit messages for additional information.

* init: add vim modeline to {,b,k}sh scripts
* lint(ShellCheck): fix SC2148 error
* lint(ShellCheck): fix SC2068 error
* lint(ShellCheck): fix SC1035 error
* lint(ShellCheck): fix SC2166 warning
* lint(ShellCheck): fix SC2178 warning
* lint(ShellCheck): fix SC2048 warning
* lint(ShellCheck): fix SC2128 warning
* lint(ShellCheck): fix SC2155 warning
* lint(ShellCheck): fix SC2086 info diagnostic
* lint(ShellCheck): fix SC2046 warning

Related: #470 