### PR TITLE
modulefile man page moved from man4 to man5

### DIFF
--- a/INSTALL-win.rst
+++ b/INSTALL-win.rst
@@ -80,5 +80,5 @@ a modulepath and contains few modulefile examples::
         module-git  module-info  null
 
 Documentation of the :ref:`module(1)` and :ref:`ml(1)` commands and
-:ref:`modulefile(4)` syntax can be found in the ``doc`` directory in
+:ref:`modulefile(5)` syntax can be found in the ``doc`` directory in
 installation directory.

--- a/MIGRATING.rst
+++ b/MIGRATING.rst
@@ -972,7 +972,7 @@ Lmod: :mfcmd:`depends-on`, :mfcmd:`prereq-any`, :mfcmd:`always-load`,
 and :mfcmd:`family`.
 
 The :ref:`Compatibility with Lmod Tcl modulefile` section in the
-:ref:`modulefile(4)` man page describes the differences existing between the
+:ref:`modulefile(5)` man page describes the differences existing between the
 two implementations.
 
 Note that when processing a :mfcmd:`family` command, the

--- a/Makefile
+++ b/Makefile
@@ -772,7 +772,7 @@ dist-tar: ChangeLog.gz contrib/rpm/environment-modules.spec pkgdoc
 		lib/configure lib/config.h.in $(DIST_AUTORECONF_EXTRA) ChangeLog.gz \
 		doc/build/MIGRATING.txt doc/build/changes.txt doc/build/INSTALL.txt \
 		doc/build/INSTALL-win.txt doc/build/NEWS.txt doc/build/CONTRIBUTING.txt \
-		doc/build/module.1.in doc/build/ml.1 doc/build/modulefile.4 \
+		doc/build/module.1.in doc/build/ml.1 doc/build/modulefile.5 \
 		contrib/rpm/environment-modules.spec
 
 dist-gzip: dist-tar

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1327,6 +1327,8 @@ Modules 4.7.0 (2021-02-19)
   from Anaïs Gaertner)
 * Doc: add a *Get Modules* section in :ref:`INSTALL` document to provide
   download links for Modules' sources. (fix issue #387)
+* Doc: move :ref:`modulefile(5)` man page in section 5. (fix issue #518 with
+  contribution from Laurent Chardon)
 
 
 .. _4.6 release notes:

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -334,7 +334,7 @@ Modules 5.2.0 (2022-11-08)
 * Add support for :option:`--all` option on :subcmd:`savelist` sub-command not
   to limit result to the collection matching currently defined
   :mconfig:`collection_target`.
-* Doc: add :ref:`Shell support` section in :ref:`modulefile(4)` man page to
+* Doc: add :ref:`Shell support` section in :ref:`modulefile(5)` man page to
   describe how shells support the different kind of environment changes that
   can be defined in modulefiles.
 * Record during :subcmd:`autoinit` sub-command the initial environment state
@@ -517,7 +517,7 @@ Modules 5.1.0 (2022-04-30)
 * Produce a clear error message when wrong number of argument is received by
   :mfcmd:`prereq` command.
 * Doc: describe :mfvar:`ModulesVersion` in *Modules Variables* section in
-  :ref:`modulefile(4)` man page.
+  :ref:`modulefile(5)` man page.
 * Set ``ModuleVersion`` as an alias over :mfvar:`ModulesVersion` modulefile
   variable for compatibility with Lmod Tcl modulefiles.
 * Doc: describe :mfcmd:`reportError` and :mfcmd:`reportWarning` modulefile
@@ -598,7 +598,7 @@ Modules 5.1.0 (2022-04-30)
   are free of misspellings (with `codespell`_ tool) and trailing spaces.
 * Doc: fix typos found in documentation with Aspell utility.
 * Doc: describe :ref:`Dependencies between modulefiles` in
-  :ref:`modulefile(4)` man page. (fix issues #431 and #433)
+  :ref:`modulefile(5)` man page. (fix issues #431 and #433)
 * Script: update :command:`pre-commit` git hook script to spell check
   documentation files with `Aspell`_ tool.
 * Script: add :command:`commit-msg` git hook script to spell check commit
@@ -627,7 +627,7 @@ Modules 5.1.0 (2022-04-30)
   modulefile is unloaded. Previous values are saved in a
   :envvar:`__MODULES_PUSHENV_\<VAR\>` environment variable.
 * Doc: add :ref:`Compatibility with Lmod Tcl modulefile` section in
-  :ref:`modulefile(4)` man page.
+  :ref:`modulefile(5)` man page.
 * Update definition of the ``module()`` python function and python
   initialization script to explicitly send output to ``sys.stderr`` to get the
   ability to catch this content.
@@ -658,9 +658,9 @@ Modules 5.1.0 (2022-04-30)
   in its header signature than the one currently in use.
 * Doc: describe :ref:`differences between run-command file and modulefile
   interpretation<Modulefile and run-command interp diff>` in
-  :ref:`modulefile(4)` man page.
+  :ref:`modulefile(5)` man page.
 * Doc: describe :mfcmd:`module` sub-commands available as modulefile Tcl
-  command for each interpretation context in :ref:`modulefile(4)` man page.
+  command for each interpretation context in :ref:`modulefile(5)` man page.
 * When loading a module with some extra tags defined through the
   :option:`--tag` option, if this module is already loaded the new tags are
   added to those already set.
@@ -1063,7 +1063,7 @@ Modules 4.7.1 (2021-04-06)
 * Revert "Install: have :file:`configure` script assume the ``.`` dot
   directory when invoked without the prepended ``./``" as consent was not
   obtained from author to re-license the contribution to GPLv2+.
-* Doc: fixes few typos in :ref:`module(1)` and :ref:`modulefile(4)`.
+* Doc: fixes few typos in :ref:`module(1)` and :ref:`modulefile(5)`.
 * Update the :subcmd:`sh-to-mod` mechanism to support version 3.2 of the fish
   shell. Fish 3.2 introduces the ``.`` builtin command that should be
   regexp-escaped when determining the shell functions or aliases defined by
@@ -1348,11 +1348,11 @@ Modules 4.6.1 (2020-11-14)
 * Doc: add *Use new features without breaking old module command* cookbook
   recipe
 * Doc: rework option description for :mfcmd:`module-hide` and
-  :mfcmd:`module-forbid` commands in :ref:`modulefile(4)` document.
+  :mfcmd:`module-forbid` commands in :ref:`modulefile(5)` document.
 * Doc: describe in :ref:`changes` document that shell special characters like
   backticks are escaped when used in values starting Modules 4.0. (fix issue
   #365)
-* Doc: make the ENVIRONMENT section from :ref:`modulefile(4)` man page point
+* Doc: make the ENVIRONMENT section from :ref:`modulefile(5)` man page point
   to the ENVIRONMENT section of :ref:`module(1)` man page.
 * Fix :subcmd:`clear` sub-command to unset the
   :envvar:`MODULES_LMSOURCESH<__MODULES_LMSOURCESH>` environment variable.
@@ -1560,7 +1560,7 @@ Modules 4.5.2 (2020-07-30)
   :file:`configure` script with the ``--option value`` syntax in addition to
   the ``--option=value`` syntax. (fix issue #348)
 * Doc: alphabetically sort sub-commands of :mfcmd:`module-info` modulefile Tcl
-  command in :ref:`modulefile(4)` document.
+  command in :ref:`modulefile(5)` document.
 * Script: clean previously built environment-modules RPMs in :command:`mrel`.
 * Clearly separate quarantine variable definition from tclsh binary on
   :file:`modulecmd.tcl` evaluated command call in ``_module_raw`` function for
@@ -1605,17 +1605,17 @@ Modules 4.5.0 (2020-04-07)
 --------------------------
 
 * Doc: fix typos and grammar mistakes on :ref:`module(1)`,
-  :ref:`modulefile(4)` and :ref:`changes` documents. (contribution from Colin
+  :ref:`modulefile(5)` and :ref:`changes` documents. (contribution from Colin
   Marquardt)
 * Doc: update cookbook recipes to highlight code of the Tcl scripts included.
   (contribution from Colin Marquardt)
-* Doc: improve markup of :ref:`module(1)`, :ref:`modulefile(4)` and
+* Doc: improve markup of :ref:`module(1)`, :ref:`modulefile(5)` and
   :ref:`changes` documents to enable references to module sub-commands,
   command line switches, environment variables and modulefile Tcl commands.
   (contribution from Colin Marquardt)
 * Doc: alphabetically sort module sub-commands, command-line switches,
   environment variables and modulefile Tcl commands in :ref:`module(1)` and
-  :ref:`modulefile(4)` documents.
+  :ref:`modulefile(5)` documents.
 * Introduce the ``ml`` command, a handy frontend to the ``module`` command.
   ``ml`` reduces the number of characters to type to trigger ``module``. With
   no argument ``ml`` is equivalent to ``module list``, ``ml mod`` corresponds
@@ -1753,7 +1753,7 @@ Modules 4.5.0 (2020-04-07)
 * Enable resolution of default module in module sub-directory when this
   default symbol targets a hidden directory (whose name starts with a dot
   character). (fix issue #331)
-* Doc: clarify hidden module location in :ref:`modulefile(4)` man page.
+* Doc: clarify hidden module location in :ref:`modulefile(5)` man page.
 * Install: define ``LD_PRELOAD`` as quarantine var along with
   ``LD_LIBRARY_PATH`` in RPM specfile.
 * When :mconfig:`implicit_default` and :mconfig:`advanced_version_spec`
@@ -2556,7 +2556,7 @@ Modules 4.2.0 (2018-10-18)
 Modules 4.1.4 (2018-08-20)
 --------------------------
 
-* Doc: fix typo on ``getenv`` command description in modulefile(4) man page
+* Doc: fix typo on ``getenv`` command description in modulefile(5) man page
   and clarify this command should be preferred over ``::env`` variable to
   query environment variable value in modulefile.
 * Init: fix ``bash`` and ``zsh`` completion scripts to enable Extended Regular
@@ -2592,7 +2592,7 @@ Modules 4.1.3 (2018-06-18)
 * Correct modulefile lookup when a modulefile directory is overwritten by a
   module alias definition but it contains an empty sub-directory. (fix
   issue#170)
-* Doc: describe ``getenv`` command in modulefile(4) man page.
+* Doc: describe ``getenv`` command in modulefile(5) man page.
 * Improve SH shell detection in profile.sh initialization script to use shell
   variable on ``bash`` or ``zsh`` to determine current shell name. (fix
   issue#173)
@@ -3165,7 +3165,7 @@ modules-tcl-1.704 (2017-01-20)
   if a modulefile is named ``default``.
 * Fix path variable counters when ``:`` character is used in elements of a
   path-like variable.
-* Update module(1) and modulefile(4) man pages to clear content specific to
+* Update module(1) and modulefile(5) man pages to clear content specific to
   the C version of Modules and add content specific to or adapt content that
   behave differently on this Tcl version.
 * Fix TCLSH variable issue in Python init script.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ type:
 
 The following man pages are provided:
 
-    module(1), ml(1), modulefile(4)
+    module(1), ml(1), modulefile(5)
 
 
 Test suite

--- a/configure
+++ b/configure
@@ -461,7 +461,7 @@ placed in the following directory structure:
       doc/
       man/
         man1/
-        man4/
+        man5/
       nagelfar/
       vim/
         vimfiles/
@@ -947,7 +947,7 @@ if [ -e 'doc/build/changes.txt' ] && [ -e 'doc/build/MIGRATING.txt' ] \
    && [ -e 'doc/build/INSTALL.txt' ] && [ -e 'doc/build/INSTALL-win.txt' ] \
    && [ -e 'doc/build/NEWS.txt' ] && [ -e 'doc/build/CONTRIBUTING.txt' ] \
    && [ -e 'doc/build/module.1.in' ] && [ -e 'doc/build/ml.1' ] \
-   && [ -e 'doc/build/modulefile.4' ] && [ "$oldbuilddoc" != 'y' ]; then
+   && [ -e 'doc/build/modulefile.5' ] && [ "$oldbuilddoc" != 'y' ]; then
    builddoc=p
 # test sphinx availability otherwise
 else

--- a/contrib/rpm/environment-modules.spec.in
+++ b/contrib/rpm/environment-modules.spec.in
@@ -225,7 +225,7 @@ fi
 %{_datadir}/modulefiles
 %{_mandir}/man1/ml.1.gz
 %{_mandir}/man1/module.1.gz
-%{_mandir}/man4/modulefile.4.gz
+%{_mandir}/man5/modulefile.5.gz
 %{macrosdir}/macros.%{name}
 %{vimdatadir}/ftdetect/modulefile.vim
 %{vimdatadir}/ftplugin/modulefile.vim

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,7 +37,7 @@ ALL_RST := $(wildcard $(SOURCE_DIR)/*.rst $(SOURCE_DIR)/cookbook/*.rst\
 	$(SOURCE_DIR)/design/*.rst)
 ALL_TXT := $(patsubst $(SOURCE_DIR)/%,$(BUILD_DIR)/%,$(patsubst %.rst,%.txt,$(ALL_RST)))
 ALL_HTML := $(patsubst $(SOURCE_DIR)/%,$(BUILD_DIR)/%,$(patsubst %.rst,%.html,$(ALL_RST)))
-ALL_MAN := $(BUILD_DIR)/module.1 $(BUILD_DIR)/ml.1 $(BUILD_DIR)/modulefile.4
+ALL_MAN := $(BUILD_DIR)/module.1 $(BUILD_DIR)/ml.1 $(BUILD_DIR)/modulefile.5
 
 all: man txt
 
@@ -97,10 +97,10 @@ $(BUILD_DIR)/%.txt: $(SOURCE_DIR)/%.rst $(SOURCE_DIR)/version.py
 	$(ECHO_GEN2) $(ECHO_DIR_PREFIX)$(BUILD_DIR)/*.txt
 	$(SPHINXBUILD) $(SPHINXOPTS) -b text "$(SOURCE_DIR)" "$(BUILD_DIR)"
 
-$(BUILD_DIR)/module.1.in $(BUILD_DIR)/modulefile.4 $(BUILD_DIR)/ml.1: $(ALL_RST) $(SOURCE_DIR)/version.py
+$(BUILD_DIR)/module.1.in $(BUILD_DIR)/modulefile.5 $(BUILD_DIR)/ml.1: $(ALL_RST) $(SOURCE_DIR)/version.py
 	$(ECHO_GEN2) $(ECHO_DIR_PREFIX)$(BUILD_DIR)/ml.1
 	$(ECHO_GEN2) $(ECHO_DIR_PREFIX)$(BUILD_DIR)/module.1.in
-	$(ECHO_GEN2) $(ECHO_DIR_PREFIX)$(BUILD_DIR)/modulefile.4
+	$(ECHO_GEN2) $(ECHO_DIR_PREFIX)$(BUILD_DIR)/modulefile.5
 	$(SPHINXBUILD) $(SPHINXOPTS) -t pathsubs -b man "$(SOURCE_DIR)" "$(BUILD_DIR)"
 	$(if $(findstring module.1.in,$@),mv $(BUILD_DIR)/module.1 $@)
 endif
@@ -109,7 +109,7 @@ $(BUILD_DIR)/module.1: $(BUILD_DIR)/module.1.in
 	$(translate-in-script)
 
 install: man txt
-	$(INSTALL_DIR) '$(DESTDIR)$(mandir)/man1' '$(DESTDIR)$(mandir)/man4'
+	$(INSTALL_DIR) '$(DESTDIR)$(mandir)/man1' '$(DESTDIR)$(mandir)/man5'
 ifeq ($(docinstall),y)
 	$(INSTALL_DIR) '$(DESTDIR)$(docdir)'
 	$(INSTALL_DATA) $(BUILD_DIR)/changes.txt '$(DESTDIR)$(docdir)/'
@@ -121,7 +121,7 @@ ifeq ($(docinstall),y)
 endif
 	$(INSTALL_DATA) $(BUILD_DIR)/module.1 '$(DESTDIR)$(mandir)/man1/'
 	$(INSTALL_DATA) $(BUILD_DIR)/ml.1 '$(DESTDIR)$(mandir)/man1/'
-	$(INSTALL_DATA) $(BUILD_DIR)/modulefile.4 '$(DESTDIR)$(mandir)/man4/'
+	$(INSTALL_DATA) $(BUILD_DIR)/modulefile.5 '$(DESTDIR)$(mandir)/man5/'
 
 uninstall:
 ifeq ($(docinstall),y)
@@ -135,8 +135,8 @@ ifeq ($(docinstall),y)
 endif
 	rm -f '$(DESTDIR)$(mandir)/man1/module.1'
 	rm -f '$(DESTDIR)$(mandir)/man1/ml.1'
-	rm -f '$(DESTDIR)$(mandir)/man4/modulefile.4'
-	rmdir '$(DESTDIR)$(mandir)/man1' '$(DESTDIR)$(mandir)/man4'
+	rm -f '$(DESTDIR)$(mandir)/man5/modulefile.5'
+	rmdir '$(DESTDIR)$(mandir)/man1' '$(DESTDIR)$(mandir)/man5'
 	rmdir '$(DESTDIR)$(mandir)'
 
 clean:

--- a/doc/source/FAQ.rst
+++ b/doc/source/FAQ.rst
@@ -121,16 +121,16 @@ I want the modulefile to source some rc script that came with some application
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 See the module :ref:`sh-to-mod_sub-command` sub-command to translate the
-environment changes done by a shell script into a :ref:`modulefile(4)`.
+environment changes done by a shell script into a :ref:`modulefile(5)`.
 
 You could also check the :ref:`source-sh_modulefile_command` to directly
 import the environment changes performed by a shell script within a
-:ref:`modulefile(4)`.
+:ref:`modulefile(5)`.
 
 How do I specify the *default* modulefile for some modulefile directory?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Modules usually uses the the highest lexicographically sorted :ref:`modulefile(4)` under the directory, unless there is a ``.version`` file in that directory which has a format like the following where ``native`` is a modulefile (or a sub-directory) in that directory. It's also possible to set the default with a ``.modulerc`` file with a **module-version** command.
+Modules usually uses the the highest lexicographically sorted :ref:`modulefile(5)` under the directory, unless there is a ``.version`` file in that directory which has a format like the following where ``native`` is a modulefile (or a sub-directory) in that directory. It's also possible to set the default with a ``.modulerc`` file with a **module-version** command.
 
 .. code-block:: tcl
 

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -5,7 +5,7 @@ Changes between versions
 
 This document lists functionality differences between each major version of Modules. The goal of each following section is to reference the features of previous major version that are missing or behave differently on the next major version and the features that can only be found on this newer version. For instance the `Modules 4`_ section lists the changes compared to Modules 3.2.
 
-Regarding deprecated or newly introduced features, this document only lists their name or the command line argument related to them. Please refer to the :ref:`module(1)` and the :ref:`modulefile(4)` man pages of the previous or newer Modules version to learn the details about these removed or added features.
+Regarding deprecated or newly introduced features, this document only lists their name or the command line argument related to them. Please refer to the :ref:`module(1)` and the :ref:`modulefile(5)` man pages of the previous or newer Modules version to learn the details about these removed or added features.
 
 
 .. _Modules 4 changes:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -296,7 +296,7 @@ rst_epilog += """.. role:: noparse
 man_pages = [
     ('module', 'module', u'command interface to the Modules package', [], 1),
     ('ml', 'ml', u'handy command interface to the Modules package', [], 1),
-    ('modulefile', 'modulefile', u'files containing Tcl code for the Modules package', [], 4)
+    ('modulefile', 'modulefile', u'files containing Tcl code for the Modules package', [], 5)
 ]
 
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -116,7 +116,7 @@ introduced by each version is available in the :ref:`MIGRATING` guide.
 new features between major versions.
 
 Reference manual page for the :ref:`module(1)` and :ref:`ml(1)` commands and
-for :ref:`modulefile(4)` script provide details on all supported options.
+for :ref:`modulefile(5)` script provide details on all supported options.
 
 A :ref:`cookbook` of recipes describes how to use the various features of
 Modules and how to extend the :command:`module` command to achieve specific

--- a/doc/source/ml.rst
+++ b/doc/source/ml.rst
@@ -88,5 +88,5 @@ the list of supported environment variables.
 SEE ALSO
 --------
 
-:ref:`module(1)`, :ref:`modulefile(4)`
+:ref:`module(1)`, :ref:`modulefile(5)`
 

--- a/doc/source/module.rst
+++ b/doc/source/module.rst
@@ -136,7 +136,7 @@ configuration` for detailed information.
 
 Afterward, :file:`modulecmd.tcl` sources rc files which contain global,
 user and *modulefile* specific setups. These files are interpreted as
-*modulefiles*. See :ref:`modulefile(4)` for detailed information.
+*modulefiles*. See :ref:`modulefile(5)` for detailed information.
 
 Upon invocation of :file:`modulecmd.tcl` module run-command files are sourced
 in the following order:
@@ -247,7 +247,7 @@ switches are accepted:
  module name. Default version is the explicitly set default version or also
  the implicit default version if the configuration option
  :mconfig:`implicit_default` is enabled (see :ref:`Locating Modulefiles`
- section in the :ref:`modulefile(4)` man page for further details on implicit
+ section in the :ref:`modulefile(5)` man page for further details on implicit
  default version).
 
  .. only:: html
@@ -346,7 +346,7 @@ switches are accepted:
 
  On :subcmd:`avail` sub-command, display only the highest numerically sorted
  version of each module name (see :ref:`Locating Modulefiles` section in the
- :ref:`modulefile(4)` man page).
+ :ref:`modulefile(5)` man page).
 
  .. only:: html
 
@@ -585,7 +585,7 @@ Module Sub-Commands
 
  Append *value* to environment *variable*. The *variable* is a colon, or
  *delimiter*, separated list. See :mfcmd:`append-path` in the
- :ref:`modulefile(4)` man page for *options* description and further
+ :ref:`modulefile(5)` man page for *options* description and further
  explanation.
 
  When :subcmd:`append-path` is called as a module sub-command, the reference
@@ -1533,7 +1533,7 @@ Module Sub-Commands
  Returns the names of currently loaded modules matching passed *modulefile*.
  Returns an empty string if passed *modulefile* does not match any loaded
  modules. See :mfcmd:`module-info loaded<module-info>` in the
- :ref:`modulefile(4)` man page for further explanation.
+ :ref:`modulefile(5)` man page for further explanation.
 
  .. only:: html
 
@@ -1602,7 +1602,7 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *modulefiles* exists in enabled
  :envvar:`MODULEPATH`. Returns a false value otherwise. See :mfcmd:`is-avail`
- in the :ref:`modulefile(4)` man page for further explanation.
+ in the :ref:`modulefile(5)` man page for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -1616,7 +1616,7 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *modulefiles* has been loaded or if
  any *modulefile* is loaded in case no argument is provided. Returns a false
- value otherwise. See :mfcmd:`is-loaded` in the :ref:`modulefile(4)` man page
+ value otherwise. See :mfcmd:`is-loaded` in the :ref:`modulefile(5)` man page
  for further explanation.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
@@ -1631,7 +1631,7 @@ Module Sub-Commands
 
  Returns a true value if any of the listed *collections* exists or if any
  *collection* exists in case no argument is provided. Returns a false value
- otherwise. See :mfcmd:`is-saved` in the :ref:`modulefile(4)` man page for
+ otherwise. See :mfcmd:`is-saved` in the :ref:`modulefile(5)` man page for
  further explanation.
 
  .. only:: html
@@ -1643,7 +1643,7 @@ Module Sub-Commands
  Returns a true value if any of the listed *directories* has been enabled in
  :envvar:`MODULEPATH` or if any *directory* is enabled in case no argument is
  provided. Returns a false value otherwise. See :mfcmd:`is-used` in the
- :ref:`modulefile(4)` man page for further explanation.
+ :ref:`modulefile(5)` man page for further explanation.
 
  .. only:: html
 
@@ -1871,7 +1871,7 @@ Module Sub-Commands
 
  Prepend *value* to environment *variable*. The *variable* is a colon, or
  *delimiter*, separated list. See :mfcmd:`prepend-path` in the
- :ref:`modulefile(4)` man page for *options* description and further
+ :ref:`modulefile(5)` man page for *options* description and further
  explanation.
 
  When :subcmd:`prepend-path` is called as a module sub-command, the reference
@@ -1943,7 +1943,7 @@ Module Sub-Commands
 .. subcmd:: remove-path [options] variable value...
 
  Remove *value* from the colon, or *delimiter*, separated list in environment
- *variable*. See :mfcmd:`remove-path` in the :ref:`modulefile(4)` man page for
+ *variable*. See :mfcmd:`remove-path` in the :ref:`modulefile(5)` man page for
  *options* description and further explanation.
 
  When :subcmd:`remove-path` is called as a module sub-command, the reference
@@ -4258,7 +4258,7 @@ ENVIRONMENT
 
  Defines (if set to ``1``) or not (if set to ``0``) an implicit default
  version for modules without a default version explicitly defined (see
- :ref:`Locating Modulefiles` section in the :ref:`modulefile(4)` man page).
+ :ref:`Locating Modulefiles` section in the :ref:`modulefile(5)` man page).
 
  Without either an explicit or implicit default version defined a module must
  be fully qualified (version should be specified in addition to its name) to
@@ -4913,7 +4913,7 @@ FILES
  to enable the default modulepaths, load the default modules and set
  :command:`module` command configuration.
 
- :file:`initrc` is a :ref:`modulefile(4)` so it is written as a Tcl script and
+ :file:`initrc` is a :ref:`modulefile(5)` so it is written as a Tcl script and
  defines modulepaths to enable with :mfcmd:`module use<module>`, modules to
  load with :mfcmd:`module load<module>` and configuration to apply with
  :subcmd:`module config<config>`. As any modulefile :file:`initrc` must begin
@@ -4980,5 +4980,5 @@ FILES
 SEE ALSO
 --------
 
-:ref:`ml(1)`, :ref:`modulefile(4)`
+:ref:`ml(1)`, :ref:`modulefile(5)`
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -1,4 +1,4 @@
-.. _modulefile(4):
+.. _modulefile(5):
 
 modulefile
 ==========

--- a/testsuite/install.00-init/030-options.exp
+++ b/testsuite/install.00-init/030-options.exp
@@ -63,7 +63,7 @@ if {$install_setmanpath eq "y" && $install_builddoc ne "n"} {
    }
    unsetenv_var MANPATH
    foreach shell $shell_list {
-      testall_cmd_re "$shell" "man -w modulefile" "$install_mandirre/man4/modulefile.*" {} 0
+      testall_cmd_re "$shell" "man -w modulefile" "$install_mandirre/man5/modulefile.*" {} 0
       testall_cmd_re "$shell" "man -w module" "$install_mandirre/man1/module.*" {} 0
    }
 } elseif {$verbose} {


### PR DESCRIPTION
modulefile man page is currently in the section 4 of man. According to `man man`, this is incorrect, as section 4 is for " Special files (usually found in /dev)". The man page for modulefile should be in section 5, "File formats and conventions, e.g. /etc/passwd".

This patch moves modulefile(4) to modulefile(5).

I hope that I didn't miss a place. Let me know if there is something that you want done differently. 

