### PR TITLE
Issue#520 explicit user group for module hide forbid tag

### DIFF
--- a/.hunspell.en.dic
+++ b/.hunspell.en.dic
@@ -1155,3 +1155,6 @@ isEnvVarDefined
 envVarEquals
 setEnvVarIfUndefined
 LMSTICKYRULE
+Chardon
+Jérémy
+Déchard

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -153,6 +153,14 @@ Modules 5.4.0 (not yet released)
   #503)
 * Init: Improve Tcsh shell completion script to complete against existing
   files when pattern starts with ``/``, ``.`` or ``~/``. (fix issue #523)
+* Add ``--user`` option to :mfcmd:`module-forbid`, :mfcmd:`module-hide` and
+  :mfcmd:`module-tag` modulefile commands to forbid, hide or tag only if user
+  is listed in the value of this new option. (fix issue #520 with contribution
+  from Jérémy Déchard)
+* Add ``--group`` option to :mfcmd:`module-forbid`, :mfcmd:`module-hide` and
+  :mfcmd:`module-tag` modulefile commands to forbid, hide or tag only if one
+  user's group is listed in the value of this new option. (fix issue #520 with
+  contribution from Jérémy Déchard)
 
 
 .. _5.3 release notes:

--- a/contrib/nagelfar/syntaxdb_modulefile.tcl
+++ b/contrib/nagelfar/syntaxdb_modulefile.tcl
@@ -261,19 +261,27 @@ set {::option(module switch)} {--tag --not-req}
 set {::option(module switch --tag)} 1
 set {::option(module unuse)} {--remove-on-unload --noop-on-unload\
    --append-on-unload --prepend-on-unload}
-set ::option(module-forbid) {--not-user --not-group --after --before\
-   --message --nearly-message}
+set ::option(module-forbid) {--user --group --not-user --not-group --after\
+   --before --message --nearly-message}
+set {::option(module-forbid --user)} 1
+set {::option(module-forbid --group)} 1
 set {::option(module-forbid --not-user)} 1
 set {::option(module-forbid --not-group)} 1
 set {::option(module-forbid --after)} 1
 set {::option(module-forbid --before)} 1
-set ::option(module-hide) {--not-user --not-group --after --before --soft\
-   --hard --hidden-loaded}
+set ::option(module-hide) {--user --group --not-user --not-group --after\
+   --before --soft --hard --hidden-loaded}
+set {::option(module-hide --user)} 1
+set {::option(module-hide --group)} 1
 set {::option(module-hide --not-user)} 1
 set {::option(module-hide --not-group)} 1
 set {::option(module-hide --after)} 1
 set {::option(module-hide --before)} 1
-set ::option(module-tag) {--not-user --not-group}
+set ::option(module-tag) {--user --group --not-user --not-group}
+set {::option(module-tag --user)} 1
+set {::option(module-tag --group)} 1
+set {::option(module-tag --not-user)} 1
+set {::option(module-tag --not-group)} 1
 set ::option(prepend-path) {-d --delim --duplicates --ignore-refcount}
 set {::option(prepend-path -d)} 1
 set {::option(prepend-path --delim)} 1

--- a/contrib/nagelfar/syntaxdb_modulerc.tcl
+++ b/contrib/nagelfar/syntaxdb_modulerc.tcl
@@ -90,18 +90,26 @@ set ::subCmd(module-info) {alias command loaded mode name shell shelltype\
 set ::subCmd(uname) {sysname nodename domain release version machine}
 
 # option
-set ::option(module-forbid) {--not-user --not-group --after --before\
-   --message --nearly-message}
+set ::option(module-forbid) {--user --group --not-user --not-group --after\
+   --before --message --nearly-message}
+set {::option(module-forbid --user)} 1
+set {::option(module-forbid --group)} 1
 set {::option(module-forbid --not-user)} 1
 set {::option(module-forbid --not-group)} 1
 set {::option(module-forbid --after)} 1
 set {::option(module-forbid --before)} 1
-set ::option(module-hide) {--not-user --not-group --after --before --soft\
-   --hard --hidden-loaded}
+set ::option(module-hide) {--user --group --not-user --not-group --after\
+   --before --soft --hard --hidden-loaded}
+set {::option(module-hide --user)} 1
+set {::option(module-hide --group)} 1
 set {::option(module-hide --not-user)} 1
 set {::option(module-hide --not-group)} 1
 set {::option(module-hide --after)} 1
 set {::option(module-hide --before)} 1
-set ::option(module-tag) {--not-user --not-group}
+set ::option(module-tag) {--user --group --not-user --not-group}
+set {::option(module-tag --user)} 1
+set {::option(module-tag --group)} 1
+set {::option(module-tag --not-user)} 1
+set {::option(module-tag --not-group)} 1
 
 # vim:set tabstop=3 shiftwidth=3 expandtab autoindent:

--- a/doc/source/changes.rst
+++ b/doc/source/changes.rst
@@ -1075,6 +1075,7 @@ The following modulefile Tcl commands appeared on Modules 5.
  * module specification on which stickiness applies is recorded in loaded
    environment to determine if it is still satisfied when updating
    environment.
+ * options ``--user`` and ``--group`` are added.
 
 :mfcmd:`break`
 

--- a/doc/source/design/hide-or-forbid-modulefile.rst
+++ b/doc/source/design/hide-or-forbid-modulefile.rst
@@ -225,6 +225,8 @@ Specification
   - ``--hard``: highest hiding level
   - ``--not-user``: specify a list of users unaffected by hide mechanism
   - ``--not-group``: specify a list of groups whose member are unaffected by hide mechanism
+  - ``--user``: specify a list of users specifically affected by hide mechanism
+  - ``--group``: specify a list of groups whose member are specifically affected by hide mechanism
   - ``--before``: enables hide mechanism until a given date
   - ``--after``: enables hide mechanism after a given date
 
@@ -232,6 +234,8 @@ Specification
 
   - ``--not-user``: specify a list of users unaffected by forbid mechanism
   - ``--not-group``: specify a list of groups whose member are unaffected by forbid mechanism
+  - ``--user``: specify a list of users specifically affected by forbid mechanism
+  - ``--group``: specify a list of groups whose member are specifically affected by forbid mechanism
   - ``--before``: enables forbid mechanism until a given date
   - ``--after``: enables forbid mechanism after a given date
   - ``--message``: supplements error message obtained when trying to evaluate a forbidden module with given text message
@@ -259,11 +263,15 @@ Specification
 
       - Unless on very specific cases, where a global rc file defines these hidden/forbidden commands for the full path modules
 
-- ``--not-user`` and ``--not-group`` specification is only supported on Unix platform
+- ``--user``, ``--group``, ``--not-user`` and ``--not-group`` specification is only supported on Unix platform
 
-  - These 2 options raise an error when used on Windows platform
+  - These options raise an error when used on Windows platform
   - In which case relative ``module-hide`` or ``module-forbid`` command is made ineffective as well as remaining content of the modulerc script hosting them
   - Error message is clearly seen when trying to load related modules and indicate where to find the erroneous command
+
+- ``--user`` and ``--group`` options prevail over ``--not-user`` and ``--not-group`` options
+
+  - When ``--user`` or ``--group`` is set, exclusion list from ``--not-user`` and ``--not-group`` are ignored
 
 - ``--before`` and ``--after`` are also supported by ``module-hide`` to phase-out modules prior to forbid their evaluation
 

--- a/doc/source/design/module-tags.rst
+++ b/doc/source/design/module-tags.rst
@@ -83,12 +83,18 @@ Defining
 
   - ``--not-user``: specify a list of users unaffected by specified tagging
   - ``--not-group``: specify a list of groups whose member are unaffected by specified tagging
+  - ``--user``: specify a list of users specifically affected by specified tagging
+  - ``--group``: specify a list of groups whose member are specifically affected by specified tagging
 
-- ``--not-user`` and ``--not-group`` specification is only supported on Unix platform
+- ``--user``, ``--group``, ``--not-user`` and ``--not-group`` specification is only supported on Unix platform
 
-  - These 2 options raise an error when used on Windows platform
+  - These options raise an error when used on Windows platform
   - In which case relative ``module-tag`` command is made ineffective as well as remaining content of the modulerc script hosting them
   - Error message is clearly seen when trying to load related modules and indicate where to find the erroneous command
+
+- ``--user`` and ``--group`` options prevail over ``--not-user`` and ``--not-group`` options
+
+  - When ``--user`` or ``--group`` is set, exclusion list from ``--not-user`` and ``--not-group`` are ignored
 
 - ``module-tag`` is intended to be used in modulerc files
 

--- a/doc/source/modulefile.rst
+++ b/doc/source/modulefile.rst
@@ -470,6 +470,8 @@ the *modulefile* is being loaded.
  * ``--before datetime``
  * ``--not-user {user...}``
  * ``--not-group {group...}``
+ * ``--user {user...}``
+ * ``--group {group...}``
  * ``--message {text message}``
  * ``--nearly-message {text message}``
 
@@ -486,6 +488,14 @@ the *modulefile* is being loaded.
  set, forbidding is not applied if current user is member of one the group
  specified. When both options are set, forbidding is not applied if a match is
  found for ``--not-user`` or ``--not-group``.
+
+ If ``--user`` option is set, forbidding is applied only if the username of
+ the user currently running :file:`modulecmd.tcl` is part of the list of
+ username specified. Following the same approach, if ``--group`` option is
+ set, forbidding is applied only if current user is member of one the group
+ specified. When both options are set, forbidding is applied if a match is
+ found for ``--user`` or ``--group``. These two options prevail over
+ ``--not-user`` and ``--not-group`` options.
 
  Error message returned when trying to evaluate a forbidden module can be
  supplemented with the *text message* set through ``--message`` option.
@@ -521,6 +531,9 @@ the *modulefile* is being loaded.
     .. versionchanged:: 5.4
        Full path file name may be used to designate *modulefile*
 
+    .. versionchanged:: 5.4
+       Options ``--user`` and ``--group`` added
+
 .. mfcmd:: module-hide [options] modulefile...
 
  Hide *modulefile* to exclude it from available module search or module
@@ -535,6 +548,8 @@ the *modulefile* is being loaded.
  * ``--before datetime``
  * ``--not-user {user...}``
  * ``--not-group {group...}``
+ * ``--user {user...}``
+ * ``--group {group...}``
 
  When ``--soft`` option is set, *modulefile* is also set hidden, but hiding is
  disabled when search or selection query's root name matches module's root
@@ -568,6 +583,14 @@ the *modulefile* is being loaded.
  hiding is not applied if current user is member of one the group specified.
  When both options are set, hiding is not applied if a match is found for
  ``--not-user`` or ``--not-group``.
+
+ If ``--user`` option is set, hiding is applied only if the username of the
+ user currently running :file:`modulecmd.tcl` is part of the list of username
+ specified. Following the same approach, if ``--group`` option is set, hiding
+ is applied only if current user is member of one the group specified. When
+ both options are set, hiding is applied if a match is found for ``--user`` or
+ ``--group``. These two options prevail over ``--not-user`` and
+ ``--not-group`` options.
 
  If the :option:`--all` option is set on :subcmd:`avail`, :subcmd:`aliases`,
  :subcmd:`whatis` or :subcmd:`search` sub-commands, hiding is disabled thus
@@ -610,6 +633,9 @@ the *modulefile* is being loaded.
 
     .. versionchanged:: 5.4
        Full path file name may be used to designate *modulefile*
+
+    .. versionchanged:: 5.4
+       Options ``--user`` and ``--group`` added
 
 .. mfcmd:: module-info option [info-args]
 
@@ -786,6 +812,8 @@ the *modulefile* is being loaded.
 
  * ``--not-user {user...}``
  * ``--not-group {group...}``
+ * ``--user {user...}``
+ * ``--group {group...}``
 
  If ``--not-user`` option is set, the tag is not applied if the username of
  the user currently running :file:`modulecmd.tcl` is part of the list of
@@ -793,6 +821,14 @@ the *modulefile* is being loaded.
  set, the tag is not applied if current user is member of one the group
  specified. When both options are set, the tag is not applied if a match is
  found for ``--not-user`` or ``--not-group``.
+
+ If ``--user`` option is set, the tag is applied only if the username of the
+ user currently running :file:`modulecmd.tcl` is part of the list of username
+ specified. Following the same approach, if ``--group`` option is set, the tag
+ is applied only if current user is member of one the group specified. When
+ both options are set, the tag is applied if a match is found for ``--user``
+ or ``--group``. These two options prevail over ``--not-user`` and
+ ``--not-group`` options.
 
  The parameter *modulefile* may also be a symbolic modulefile name or a
  modulefile alias. It may also leverage a specific syntax to finely select
@@ -821,6 +857,9 @@ the *modulefile* is being loaded.
 
     .. versionchanged:: 5.4
        Full path file name may be used to designate *modulefile*
+
+    .. versionchanged:: 5.4
+       Options ``--user`` and ``--group`` added
 
 .. mfcmd:: module-version modulefile version-name...
 

--- a/tcl/mfcmd.tcl
+++ b/tcl/mfcmd.tcl
@@ -308,13 +308,18 @@ proc parseApplicationCriteriaArgs {aftbef nearsec args} {
    set isafter [expr {[info exists after] && [getState clock_seconds] >=\
       $after}]
 
-   # are criteria met
-   set apply [expr {!$notuser && !$notgroup && ($isbefore || $isafter ||\
-      (![info exists before] && ![info exists after]))}]
+
+   set user_or_group_excluded [expr {$notuser || $notgroup}]
+   set time_frame_defined [expr {[info exists before] || [info exists after]}]
+   set in_time_frame [expr {!$time_frame_defined || $isbefore || $isafter}]
+   set in_near_time_frame [expr {[info exists after] && !$isafter &&\
+      [getState clock_seconds] >= ($after - $nearsec)}]
+
+   set apply [expr {$in_time_frame && !$user_or_group_excluded}]
 
    # is end limit near ?
-   set isnearly [expr {!$apply && !$notuser && !$notgroup && [info exists\
-      after] && !$isafter && [getState clock_seconds] >= ($after - $nearsec)}]
+   set isnearly [expr {!$apply && !$user_or_group_excluded &&\
+      $in_near_time_frame}]
    if {![info exists afterraw]} {
       set afterraw {}
    }

--- a/testsuite/modulefiles.2/hide1/.modulerc
+++ b/testsuite/modulefiles.2/hide1/.modulerc
@@ -713,3 +713,74 @@ if {[info exists env(TESTSUITE_HIDE_USER_GROUP)]} {
         }
     }
 }
+
+# 20/117 --user and --group tests
+if {[info exists env(TESTSUITE_FORBID_USER_GROUP)]} {
+    switch -- $env(TESTSUITE_FORBID_USER_GROUP) {
+        user2 {
+            module-forbid --user [list unknown1 [module-info username] unknown2] hide1
+        }
+        user3 {
+            module-forbid --user [list unknown1 unknown2] hide1
+        }
+        user_time1 {
+            set tomorrow [clock format [expr {[clock seconds]+86400}] -format %Y-%m-%d]
+            module-forbid --user [module-info username] --after $tomorrow hide1
+        }
+        user_time2 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-forbid --user [module-info username] --after $yesterday hide1
+        }
+        user_time3 {
+            set tomorrow [clock format [expr {[clock seconds]+86400}] -format %Y-%m-%d]
+            module-forbid --user unknown1 --after $tomorrow hide1
+        }
+        user_time4 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-forbid --user unknown1 --after $yesterday hide1
+        }
+        user_notgroup3 {
+            module-forbid --user [module-info username] --not-group [module-info usergroups] hide1
+        }
+        user_notgroup4 {
+            module-forbid --user unknown1 --not-group unknown1 hide1
+        }
+        group2 {
+            module-forbid --group [concat [list unknown1 unknown2] [module-info usergroups]] hide1
+        }
+        group3 {
+            module-forbid --group [list unknown1 unknown2] hide1
+        }
+        group_time1 {
+            set tomorrow [clock format [expr {[clock seconds]+86400}] -format %Y-%m-%d]
+            module-forbid --group [module-info usergroups] --after $tomorrow hide1
+        }
+        group_time2 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-forbid --group [module-info usergroups] --after $yesterday hide1
+        }
+        group_time3 {
+            set tomorrow [clock format [expr {[clock seconds]+86400}] -format %Y-%m-%d]
+            module-forbid --group unknown1 --after $tomorrow hide1
+        }
+        group_time4 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-forbid --group unknown1 --after $yesterday hide1
+        }
+        group_notuser1 {
+            module-forbid --group [module-info usergroups] --not-user unknown1 hide1
+        }
+        group_notuser2 {
+            module-forbid --group unknown1 --not-user [module-info username] hide1
+        }
+        group_user1 {
+            module-forbid --group [module-info usergroups] --user unknown1 hide1
+        }
+        group_user2 {
+            module-forbid --group unknown1 --user [module-info username] hide1
+        }
+        group_user_notuser_notgroup2 {
+            module-forbid --group unknown1 --user unknown1 hide1 --not-user unknown1 --not-group unknown1 hide1
+        }
+    }
+}

--- a/testsuite/modulefiles.2/hide1/.modulerc
+++ b/testsuite/modulefiles.2/hide1/.modulerc
@@ -548,3 +548,168 @@ if {[info exists env(TESTSUITE_HIDE1_CASC_SET7)]} {
 if {[info exists env(TESTSUITE_HIDE1_CASC_SET8)]} {
     module-hide hide1
 }
+
+# 20/112 --user and --group tests
+if {[info exists env(TESTSUITE_HIDE_USER_GROUP)]} {
+    switch -- $env(TESTSUITE_HIDE_USER_GROUP) {
+        bad_user1 {
+            module-hide --user hide1
+        }
+        bad_user2 {
+            module-hide --user
+        }
+        user1 {
+            module-hide --user [module-info username] hide1
+        }
+        user2 {
+            module-hide --user [list unknown1 [module-info username] unknown2] hide1
+        }
+        user3 {
+            module-hide --user [list unknown1 unknown2] hide1
+        }
+        user4 {
+            module-hide --user {} hide1
+        }
+        user_time1 {
+            set tomorrow [clock format [expr {[clock seconds]+86400}] -format %Y-%m-%d]
+            module-hide --user [module-info username] --after $tomorrow hide1
+        }
+        user_time2 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-hide --user [module-info username] --after $yesterday hide1
+        }
+        user_multi1 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-hide --not-user [module-info username] hide1
+            module-hide --user [module-info username] --after $yesterday hide1
+        }
+        user_multi2 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-hide --user [module-info username] --after $yesterday hide1
+            module-hide --not-user [module-info username] hide1
+        }
+        user_notuser1 {
+            module-hide --user [module-info username] --not-user unknown1 hide1
+        }
+        user_notuser2 {
+            module-hide --user unknown1 --not-user [module-info username] hide1
+        }
+        user_notuser3 {
+            module-hide --user [module-info username] --not-user [module-info username] hide1
+        }
+        user_notuser4 {
+            module-hide --user unknown1 --not-user unknown1 hide1
+        }
+        user_notgroup1 {
+            module-hide --user [module-info username] --not-group unknown1 hide1
+        }
+        user_notgroup2 {
+            module-hide --user unknown1 --not-group [module-info usergroups] hide1
+        }
+        user_notgroup3 {
+            module-hide --user [module-info username] --not-group [module-info usergroups] hide1
+        }
+        user_notgroup4 {
+            module-hide --user unknown1 --not-group unknown1 hide1
+        }
+        user_notuser_notgroup1 {
+            module-hide --user [module-info username] --not-user [module-info username] --not-group unknown1 hide1
+        }
+        user_notuser_notgroup2 {
+            module-hide --user [module-info username] --not-user [module-info username] --not-group [module-info usergroups] hide1
+        }
+        user_notuser_notgroup3 {
+            module-hide --user unknown1 --not-user unknown1 --not-group unknown1 hide1
+        }
+        bad_group1 {
+            module-hide --group hide1
+        }
+        bad_group2 {
+            module-hide --group
+        }
+        group1 {
+            module-hide --group [module-info usergroups] hide1
+        }
+        group2 {
+            module-hide --group [concat [list unknown1 unknown2] [module-info usergroups]] hide1
+        }
+        group3 {
+            module-hide --group [list unknown1 unknown2] hide1
+        }
+        group4 {
+            module-hide --group {} hide1
+        }
+        group_time1 {
+            set tomorrow [clock format [expr {[clock seconds]+86400}] -format %Y-%m-%d]
+            module-hide --group [module-info usergroups] --after $tomorrow hide1
+        }
+        group_time2 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-hide --group [module-info usergroups] --after $yesterday hide1
+        }
+        group_multi1 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-hide --not-group [module-info usergroups] hide1
+            module-hide --group [module-info usergroups] --after $yesterday hide1
+        }
+        group_multi2 {
+            set yesterday [clock format [expr {[clock seconds]-86400}] -format %Y-%m-%d]
+            module-hide --group [module-info usergroups] --after $yesterday hide1
+            module-hide --not-group [module-info usergroups] hide1
+        }
+        group_notgroup1 {
+            module-hide --group [module-info usergroups] --not-group unknown1 hide1
+        }
+        group_notgroup2 {
+            module-hide --group unknown1 --not-group [module-info usergroups] hide1
+        }
+        group_notgroup3 {
+            module-hide --group [module-info usergroups] --not-group [module-info usergroups] hide1
+        }
+        group_notgroup4 {
+            module-hide --group unknown1 --not-group unknown1 hide1
+        }
+        group_notuser1 {
+            module-hide --group [module-info usergroups] --not-user unknown1 hide1
+        }
+        group_notuser2 {
+            module-hide --group unknown1 --not-user [module-info username] hide1
+        }
+        group_notuser3 {
+            module-hide --group [module-info usergroups] --not-user [module-info username] hide1
+        }
+        group_notuser4 {
+            module-hide --group unknown1 --not-user unknown1 hide1
+        }
+        group_notuser_notgroup1 {
+            module-hide --group [module-info usergroups] --not-user [module-info username] --not-group unknown1 hide1
+        }
+        group_notuser_notgroup2 {
+            module-hide --group [module-info usergroups] --not-user [module-info username] --not-group [module-info usergroups] hide1
+        }
+        group_notuser_notgroup3 {
+            module-hide --group unknown1 --not-user unknown1 --not-group unknown1 hide1
+        }
+        group_user1 {
+            module-hide --group [module-info usergroups] --user unknown1 hide1
+        }
+        group_user2 {
+            module-hide --group unknown1 --user [module-info username] hide1
+        }
+        group_user3 {
+            module-hide --group [module-info usergroups] --user [module-info username] hide1
+        }
+        group_user4 {
+            module-hide --group unknown1 --user unknown1 hide1
+        }
+        group_user_notuser_notgroup1 {
+            module-hide --group unknown1 --user unknown1 hide1 --not-user [module-info username] --not-group unknown1 hide1
+        }
+        group_user_notuser_notgroup2 {
+            module-hide --group unknown1 --user unknown1 hide1 --not-user unknown1 --not-group unknown1 hide1
+        }
+        group_user_notuser_notgroup3 {
+            module-hide --group unknown1 --user [module-info username] --not-user [module-info username] --not-group [module-info usergroups] hide1
+        }
+    }
+}

--- a/testsuite/modulefiles.3/tag/.modulerc
+++ b/testsuite/modulefiles.3/tag/.modulerc
@@ -177,3 +177,42 @@ if {[info exists env(TESTSUITE_STASH)]} {
         }
     }
 }
+
+# --user/--group tests in 50/440
+if {[info exists env(TESTSUITE_TAG_USER_GROUP)]} {
+    switch -- $env(TESTSUITE_TAG_USER_GROUP) {
+        user2 {
+            module-tag --user [list unknown1 [module-info username] unknown2] foo tag
+        }
+        user3 {
+            module-tag --user [list unknown1 unknown2] foo tag
+        }
+        user_notgroup3 {
+            module-tag --user [module-info username] --not-group [module-info usergroups] foo tag
+        }
+        user_notgroup4 {
+            module-tag --user unknown1 --not-group unknown1 foo tag
+        }
+        group2 {
+            module-tag --group [concat [list unknown1 unknown2] [module-info usergroups]] foo tag
+        }
+        group3 {
+            module-tag --group [list unknown1 unknown2] foo tag
+        }
+        group_notuser1 {
+            module-tag --group [module-info usergroups] --not-user unknown1 foo tag
+        }
+        group_notuser2 {
+            module-tag --group unknown1 --not-user [module-info username] foo tag
+        }
+        group_user1 {
+            module-tag --group [module-info usergroups] --user unknown1 foo tag
+        }
+        group_user2 {
+            module-tag --group unknown1 --user [module-info username] foo tag
+        }
+        group_user_notuser_notgroup2 {
+            module-tag --group unknown1 --user unknown1 foo tag --not-user unknown1 --not-group unknown1 hide1
+        }
+    }
+}

--- a/testsuite/modules.20-locate/112-hide-user-group.exp
+++ b/testsuite/modules.20-locate/112-hide-user-group.exp
@@ -255,6 +255,242 @@ unsetenv_var TESTSUITE_HIDE_ALLOW_USER_GROUP_ERR_SET3
 
 
 #
+# test --user option
+#
+
+set tserr1 $mp:\nhide1/5.0
+
+setenv_var TESTSUITE_HIDE_USER_GROUP bad_user1
+
+if {[cmpversion $tclsh_version 8.6] == -1} {
+    set custom "    invoked from within
+\"if \{\[info exists env(TESTSUITE_HIDE_USER_GROUP)\]\} \{
+    switch -- \$env(TESTSUITE_HIDE_USER_GROUP) \{
+        bad_user1 \{
+            module-hide --user...\""
+    set linenum 553
+} else {
+    set custom {}
+    set linenum 556
+}
+set tserr [msg_moderr {No module specified in argument} {module-hide --user hide1} $mp/hide1/.modulerc $linenum {  } {} {} $custom]
+testouterr_cmd sh {load hide1@5:} $ans2 $tserr
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP bad_user2
+
+if {[cmpversion $tclsh_version 8.6] == -1} {
+    set custom "    invoked from within
+\"if \{\[info exists env(TESTSUITE_HIDE_USER_GROUP)\]\} \{
+    switch -- \$env(TESTSUITE_HIDE_USER_GROUP) \{
+        bad_user1 \{
+            module-hide --user...\""
+    set linenum 553
+} else {
+    set custom {}
+    set linenum 559
+}
+set tserr [msg_moderr {Missing value for '--user' option} {module-hide --user} $mp/hide1/.modulerc $linenum {  } {} {} $custom]
+testouterr_cmd sh {load hide1@5:} $ans2 $tserr
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user3
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_time1
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_time2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_multi1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_multi2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser2
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser3
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notgroup1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notgroup2
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notgroup3
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notgroup4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser_notgroup1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser_notgroup2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP user_notuser_notgroup3
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+#
+# test --group option
+#
+
+set tserr1 $mp:\nhide1/5.0
+
+setenv_var TESTSUITE_HIDE_USER_GROUP bad_group1
+
+if {[cmpversion $tclsh_version 8.6] == -1} {
+    set custom "    invoked from within
+\"if \{\[info exists env(TESTSUITE_HIDE_USER_GROUP)\]\} \{
+    switch -- \$env(TESTSUITE_HIDE_USER_GROUP) \{
+        bad_user1 \{
+            module-hide --user...\""
+    set linenum 553
+} else {
+    set custom {}
+    set linenum 625
+}
+set tserr [msg_moderr {No module specified in argument} {module-hide --group hide1} $mp/hide1/.modulerc $linenum {  } {} {} $custom]
+testouterr_cmd sh {load hide1@5:} $ans2 $tserr
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP bad_group2
+
+if {[cmpversion $tclsh_version 8.6] == -1} {
+    set custom "    invoked from within
+\"if \{\[info exists env(TESTSUITE_HIDE_USER_GROUP)\]\} \{
+    switch -- \$env(TESTSUITE_HIDE_USER_GROUP) \{
+        bad_user1 \{
+            module-hide --user...\""
+    set linenum 553
+} else {
+    set custom {}
+    set linenum 628
+}
+set tserr [msg_moderr {Missing value for '--group' option} {module-hide --group} $mp/hide1/.modulerc $linenum {  } {} {} $custom]
+testouterr_cmd sh {load hide1@5:} $ans2 $tserr
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group3
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_time1
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_time2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_multi1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_multi2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notgroup1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notgroup2
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notgroup3
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notgroup4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser2
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser3
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser_notgroup1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser_notgroup2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_notuser_notgroup3
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+
+#
+# test mix of --user and --group options
+#
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user1
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user2
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user3
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user4
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user_notuser_notgroup1
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user_notuser_notgroup2
+testouterr_cmd sh {avail -t hide1@5:} OK $tserr1
+
+setenv_var TESTSUITE_HIDE_USER_GROUP group_user_notuser_notgroup3
+testouterr_cmd sh {avail -t hide1@5:} OK {}
+
+
+#
 #  Cleanup
 #
 

--- a/testsuite/modules.20-locate/117-forbid-user-group.exp
+++ b/testsuite/modules.20-locate/117-forbid-user-group.exp
@@ -140,6 +140,74 @@ unsetenv_var TESTSUITE_FORBID_ALLOW_USER_GROUP_ERR_SET2
 
 
 #
+# --user/--group options test
+#
+
+setenv_var MODULES_NEARLY_FORBIDDEN_DAYS 2
+
+set tserr_forbidden "$mp:\nhide1/5.0 <F>"
+set tserr_not_forbidden $mp:\nhide1/5.0
+set tserr_nearly_forbidden "$mp:\nhide1/5.0 <nF>"
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user3
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user_time1
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_nearly_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user_time2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user_time3
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user_time4
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user_notgroup3
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP user_notgroup4
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group3
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_time1
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_nearly_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_time2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_time3
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_time4
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_notuser1
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_notuser2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_user1
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_user2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_forbidden
+
+setenv_var TESTSUITE_FORBID_USER_GROUP group_user_notuser_notgroup2
+testouterr_cmd sh {avail -t hide1/5.0} OK $tserr_not_forbidden
+
+
+#
 #  Cleanup
 #
 

--- a/testsuite/modules.50-cmds/440-module-tag.exp
+++ b/testsuite/modules.50-cmds/440-module-tag.exp
@@ -368,6 +368,47 @@ setenv_var MODULERCFILE $ORIG_MODULERCFILE
 
 
 #
+# --user/--group options test
+#
+
+set tserr_wtag "$mp:\ntag/5.0 <foo>"
+set tserr_notag $mp:\ntag/5.0
+
+setenv_var TESTSUITE_TAG_USER_GROUP user2
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_wtag
+
+setenv_var TESTSUITE_TAG_USER_GROUP user3
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_notag
+
+setenv_var TESTSUITE_TAG_USER_GROUP user_notgroup3
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_wtag
+
+setenv_var TESTSUITE_TAG_USER_GROUP user_notgroup4
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_notag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group2
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_wtag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group3
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_notag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group_notuser1
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_wtag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group_notuser2
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_notag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group_user1
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_wtag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group_user2
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_wtag
+
+setenv_var TESTSUITE_TAG_USER_GROUP group_user_notuser_notgroup2
+testouterr_cmd sh {avail -t tag/5.0} OK $tserr_notag
+
+
+#
 #  Cleanup
 #
 


### PR DESCRIPTION
Open PR to review code for explicit `user`/ `group` option in `module-{hide,forbid,tag}` command (see issue [here.](https://github.com/cea-hpc/modules/issues/520).

Code review needed to not use the boolean `flag`.