### PR TITLE
Add simple completion (loaded modules, avail modules) to "ml" command

### DIFF
--- a/init/Makefile
+++ b/init/Makefile
@@ -119,7 +119,8 @@ endif
 
 # define variables for shell completion
 comp_cmds := add add-any apropos aliases avail append-path cachebuild cacheclear clear config del display edit help initadd initclear initlist initprepend initrm is-loaded is-saved is-used is-avail info-loaded keyword lint list load load-any mod-to-sh path paths purge prepend-path refresh reload reset restore rm remove remove-path save savelist saveshow saverm search show sh-to-mod source stash stashclear stashlist stashpop stashrm stashshow state swap switch test try-add try-load unload unuse use whatis
-comp_opts := -D -h -s -T -v -V -w --debug --help --silent --trace --verbose --version --paginate --no-pager --color --color= --width --width= --ignore-cache --ignore-user-rc
+comp_long_opts := --debug --help --silent --trace --verbose --version --paginate --no-pager --color --color= --width --width= --ignore-cache --ignore-user-rc
+comp_opts := -D -h -s -T -v -V -w $(comp_long_opts)
 comp_load_opts := --auto --no-auto --force -f --icase -i --tag --tag=
 comp_unload_opts := --auto --no-auto --force -f --icase -i
 comp_list_opts := -a -j -l -o -t --all --json --long --output --output= --terse
@@ -148,6 +149,7 @@ sed -e 's|@prefix@|$(prefix)|g' \
 	-e 's|@bindir@|$(bindir)|g' \
 	-e 's|@mandir@|$(mandir)|g' \
 	-e 's|@comp_cmds@|$(comp_cmds)|g' \
+	-e 's|@comp_long_opts@|$(comp_long_opts)|g' \
 	-e 's|@comp_opts@|$(comp_opts)|g' \
 	-e 's|@comp_load_opts@|$(comp_load_opts)|g' \
 	-e 's|@comp_unload_opts@|$(comp_unload_opts)|g' \

--- a/init/tcsh_completion.in
+++ b/init/tcsh_completion.in
@@ -108,6 +108,8 @@ complete module 'C,/*,f,' 'C,.*,f,' 'C,~/*,f,' \
         "p/1/(@comp_cmds@ @comp_opts@)/" \
         "n/-*/(@comp_cmds@)/"
 
-complete ml 'c/-/`_module_loaded`/' \
-            'p/1-/`_module_not_yet_loaded`//'
+complete ml \
+        "C/--*/(@comp_long_opts@)/" \
+        'c/-/`_module_loaded`/' \
+        'p/1-/`_module_not_yet_loaded`//'
 

--- a/init/tcsh_completion.in
+++ b/init/tcsh_completion.in
@@ -107,3 +107,7 @@ complete module 'C,/*,f,' 'C,.*,f,' 'C,~/*,f,' \
         'C/sw*/(switch)/' \
         "p/1/(@comp_cmds@ @comp_opts@)/" \
         "n/-*/(@comp_cmds@)/"
+
+complete ml 'c/-/`_module_loaded`/' \
+            'p/1-/`_module_not_yet_loaded`//'
+


### PR DESCRIPTION
Add simple completion on "ml" command under tcsh.
This fix will allow to list unload module when user hit "tab" after "ml" command and will list loaded modules after "ml -"
All other completions (as for full "module" command) are not implemented to keep it simple