### PR TITLE
Add -encoding option to superseded source command

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -73,6 +73,9 @@ Modules 5.7.0 (not yet released)
 * Improve the performance of the module’s column output by removing the costly
   optimization that attempts to fit more columns within the available screen
   width. (fix issue #622)
+* Fix superseding definition of ``source`` Tcl command when
+  :mconfig:`source_cache` configuration option is enabled to support
+  ``-encoding`` option. (fix issue #627)
 
 
 .. _5.6 release notes:

--- a/tcl/mfcmd.tcl
+++ b/tcl/mfcmd.tcl
@@ -2278,7 +2278,23 @@ proc unique-name-conflict {} {
    conflict {*}$root_name_list
 }
 
-proc sourceModfileCmd {itrp filename} {
+proc sourceModfileCmd {itrp args} {
+   # argument parsing: catch encoding arg but ignore it
+   switch -- [llength $args] {
+      1 {}
+      3 {
+         set option [lindex $args 0]
+         if {$option ne {-encoding}} {
+            knerror "Invalid option '$option'"
+         }
+      }
+      default {
+         knerror {wrong # args: should be "source ?-encoding? ?encodingName?\
+            fileName"}
+      }
+   }
+   set filename [lindex $args end]
+
    if {![info exists ::source_cache($filename)]} {
       set ::source_cache($filename) [readFile $filename]
    }

--- a/testsuite/modulefiles.4/source/1.0
+++ b/testsuite/modulefiles.4/source/1.0
@@ -31,5 +31,17 @@ if {[info exists env(TESTSUITE_SOURCE_CACHE)]} {
             source ../path/to/unk
             setenv VAR bar
         }
+        arg1 {
+            source -encoding utf-8 [file dirname $ModulesCurrentModulefile]/source_file
+        }
+        bad_arg1 {
+            source -encoding [file dirname $ModulesCurrentModulefile]/source_file
+        }
+        bad_arg2 {
+            source -foo bar [file dirname $ModulesCurrentModulefile]/source_file
+        }
+        bad_arg3 {
+            source -encoding utf-8 -foo bar [file dirname $ModulesCurrentModulefile]/source_file
+        }
     }
 }

--- a/testsuite/modulefiles.4/source/source_file
+++ b/testsuite/modulefiles.4/source/source_file
@@ -40,5 +40,8 @@ if {[info exists env(TESTSUITE_SOURCE_CACHE)]} {
         break1 {
             break
         }
+        arg1 - bad_arg1 - bad_arg2 {
+            setenv VAR bar
+        }
     }
 }

--- a/testsuite/modules.50-cmds/620-source_cache.exp
+++ b/testsuite/modules.50-cmds/620-source_cache.exp
@@ -290,6 +290,30 @@ testouterr_cmd_re bash {load source/1.0} $ans_load $ts_load
 
 }
 
+
+# check argument management
+setenv_var MODULES_SOURCE_CACHE 1
+setenv_var TESTSUITE_SOURCE_CACHE arg1
+set ans [list]
+lappend ans [list set VAR bar]
+lappend ans [list set _LMFILES_ $mp/source/1.0]
+lappend ans [list set LOADEDMODULES source/1.0]
+testouterr_cmd bash {load source/1.0} $ans {}
+
+setenv_var TESTSUITE_SOURCE_CACHE bad_arg1
+set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 2 : 38}]
+set tserr [escre [msg_load source/1.0 [msg_moderr {wrong # args: should be "source ?-encoding? ?encodingName? fileName"} {source<EXM>} $mp/source/1.0 $line_num]]]
+testouterr_cmd_re bash {load source/1.0} ERR $tserr
+set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 2 : 41}]
+set tserr [escre [msg_load source/1.0 [msg_moderr {Invalid option '-foo'} {source<EXM>} $mp/source/1.0 $line_num]]]
+setenv_var TESTSUITE_SOURCE_CACHE bad_arg2
+testouterr_cmd_re bash {load source/1.0} ERR $tserr
+setenv_var TESTSUITE_SOURCE_CACHE bad_arg3
+set line_num [expr {[cmpversion $tclsh_version 8.6] == -1 ? 2 : 44}]
+set tserr [escre [msg_load source/1.0 [msg_moderr {wrong # args: should be "source ?-encoding? ?encodingName? fileName"} {source<EXM>} $mp/source/1.0 $line_num]]]
+testouterr_cmd_re bash {load source/1.0} ERR $tserr
+
+
 # cannot test access if cannot change file permission
 if {!$is_file_perms_editable} {
     send_user "\tskipping access tests as file permissions cannot be changed\n"


### PR DESCRIPTION
Fix superseding definition of "source" Tcl command when "source_cache" configuration option is enabled to support "-encoding" option.

The value set to this encoding option is currently ignored.

Closes #627