### PR TITLE
Enable lexical binding in environment-modules-init.el

### DIFF
--- a/share/emacs/lisp/environment-modules-init.el
+++ b/share/emacs/lisp/environment-modules-init.el
@@ -1,7 +1,14 @@
-;; Activate modulefile-mode
+;;; environment-modules-init.el --- Autoload modulefile-mode  -*- lexical-binding: t; -*-
 
-;; Use first line of file to recognize file type
+;;; Commentary:
+;;
+;; Activate modulefile-mode.  Use first line of file to recognize file type.
+
+;;; Code:
+
 (add-to-list 'magic-mode-alist '("#%Module" . modulefile-mode))
 
 (autoload 'modulefile-mode "modulefile-mode"
   "Major mode for editing Modulefile scripts." t)
+
+;;; environment-modules-init.el ends here


### PR DESCRIPTION
Fixes the following unsightly warning in Emacs 31:

```
⛔ Warning (files): Missing ‘lexical-binding’ cookie in "/usr/share/emacs/site-lisp/site-start.d/environment-modules-init.el".
You can add one with ‘M-x elisp-enable-lexical-binding RET’.
See ‘(elisp)Selecting Lisp Dialect’ and ‘(elisp)Converting to Lexical Binding’
for more information.
```

While we’re here, keep `checkdoc` happy.