### PR TITLE
Correctly match loaded modules against trailing / spec

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -106,6 +106,8 @@ Modules 5.7.0 (not yet released)
 * Enable lexical binding in Emacs addon file. (contribution from Peter Oliver)
 * Script: update :command:`mt` utility to analyze test suite log file when
   test suite run is aborted.
+* Correctly match loaded modules specified as requirement with a trailing
+  ``/`` character after module name. (fix issue #640)
 
 
 .. _5.6 release notes:

--- a/tcl/modspec.tcl
+++ b/tcl/modspec.tcl
@@ -622,11 +622,15 @@ proc modEqProc {pattern mod {test equal} {trspec 1} {ismodlo 0} {vrcmp 0}\
       set pmod $pattern
    }
    # trim dup trailing / char and adapt pmod suffix if it starts with /
+   set endwslash 0
    if {[string index $pmod end] eq {/}} {
-      set pmod [string trimright $pmod /]/
-      set endwslash 1
-   } else {
-      set endwslash 0
+      #  trailing / will be automatically added in the eqstart tests
+      if {$test eq {eqstart}} {
+         set pmod [string trimright $pmod /]
+      } else {
+         set pmod [string trimright $pmod /]/
+         set endwslash 1
+      }
    }
    # get alternative names if mod is loading(1) or loaded(2)
    set altlist [switch -- $ismodlo {
@@ -759,11 +763,14 @@ proc modEqProcIcase {pattern mod {test equal} {trspec 1} {ismodlo 0} {vrcmp\
    } else {
       set pmod $pattern
    }
+   set endwslash 0
    if {[string index $pmod end] eq {/}} {
-      set pmod [string trimright $pmod /]/
-      set endwslash 1
-   } else {
-      set endwslash 0
+      if {$test eq {eqstart}} {
+         set pmod [string trimright $pmod /]
+      } else {
+         set pmod [string trimright $pmod /]/
+         set endwslash 1
+      }
    }
    set altlist [switch -- $ismodlo {
       7 {getLoadedAltname $mod {alias}}
@@ -888,11 +895,14 @@ proc modEqProcExtdfl {pattern mod {test equal} {trspec 1} {ismodlo 0} {vrcmp\
    } else {
       set pmod $pattern
    }
+   set endwslash 0
    if {[string index $pmod end] eq {/}} {
-      set pmod [string trimright $pmod /]/
-      set endwslash 1
-   } else {
-      set endwslash 0
+      if {$test eq {eqstart}} {
+         set pmod [string trimright $pmod /]
+      } else {
+         set pmod [string trimright $pmod /]/
+         set endwslash 1
+      }
    }
    set altlist [switch -- $ismodlo {
       7 {getLoadedAltname $mod {alias}}
@@ -1033,11 +1043,14 @@ proc modEqProcIcaseExtdfl {pattern mod {test equal} {trspec 1} {ismodlo 0}\
    } else {
       set pmod $pattern
    }
+   set endwslash 0
    if {[string index $pmod end] eq {/}} {
-      set pmod [string trimright $pmod /]/
-      set endwslash 1
-   } else {
-      set endwslash 0
+      if {$test eq {eqstart}} {
+         set pmod [string trimright $pmod /]
+      } else {
+         set pmod [string trimright $pmod /]/
+         set endwslash 1
+      }
    }
    set altlist [switch -- $ismodlo {
       7 {getLoadedAltname $mod {alias}}

--- a/testsuite/modulefiles.4/foo/1.0
+++ b/testsuite/modulefiles.4/foo/1.0
@@ -73,3 +73,13 @@ if {[info exists env(TESTSUITE_MODULEPATH_OPT)]} {
         }
     }
 }
+if {[info exists env(TESTSUITE_PREREQ)]} {
+    switch -- $env(TESTSUITE_PREREQ) {
+        prereq_slash {
+            prereq bar/
+        }
+        prereq_at {
+            prereq bar@
+        }
+    }
+}

--- a/testsuite/modules.50-cmds/121-prereq-module.exp
+++ b/testsuite/modules.50-cmds/121-prereq-module.exp
@@ -136,6 +136,34 @@ lappend ans [list set LOADEDMODULES "$module_troff:$module_tron:$module"]
 lappend ans [list set testsuite yes]
 testouterr_cmd_re "sh" "switch --auto $module_set $module_tron" $ans [msg_load $module_tron $err_trace]\n\n[msg_top_switch $module_set $module_tron {} {} {} {} $module]
 
+
+# test prereq command with module spec with trailng slash/at character
+unsetenv_loaded_module
+unsetenv_var __MODULES_LMPREREQ
+setenv_var MODULEPATH $modpath.4
+setenv_var TESTSUITE_PREREQ prereq_slash
+setenv_var MODULES_ADVANCED_VERSION_SPEC 1
+setenv_var MODULES_IMPLICIT_DEFAULT 1
+
+set ans [list]
+lappend ans [list set __MODULES_LMALTNAME bar/2&as|bar/default&as|bar/latest]
+lappend ans [list set __MODULES_LMPREREQ foo/1.0&bar/]
+lappend ans [list set _LMFILES_ $modpath.4/bar/2:$modpath.4/foo/1.0]
+lappend ans [list set LOADEDMODULES bar/2:foo/1.0]
+lappend ans [list set __MODULES_LMTAG bar/2&auto-loaded]
+set tserr [msg_top_load foo/1.0 {} bar/2 {}]
+testouterr_cmd sh {load --auto foo/1.0} $ans $tserr
+
+setenv_var TESTSUITE_PREREQ prereq_at
+set ans [list]
+lappend ans [list set __MODULES_LMALTNAME bar/2&as|bar/default&as|bar/latest]
+lappend ans [list set __MODULES_LMPREREQ foo/1.0&bar@]
+lappend ans [list set _LMFILES_ $modpath.4/bar/2:$modpath.4/foo/1.0]
+lappend ans [list set LOADEDMODULES bar/2:foo/1.0]
+lappend ans [list set __MODULES_LMTAG bar/2&auto-loaded]
+testouterr_cmd sh {load --auto foo/1.0} $ans $tserr
+
+
 #
 #  Cleanup
 #


### PR DESCRIPTION
Match loaded modules when specified as requirement with a trailing slash character after module name (e.g., foo/).

Closes #640