### PR TITLE
Added completion on fish shell for ml command

### DIFF
--- a/init/fish_completion
+++ b/init/fish_completion
@@ -72,112 +72,128 @@ function __fish_module_use_config --description 'Test if module command should h
    return 1
 end
 
-complete -c module -n '__fish_module_use_avail' -f -a "(module avail --color=never -s -t -S --no-indepth -o 'alias:indesym' (commandline -ct) 2>&1)"
-complete -c module -n '__fish_module_use_spider' -f -a "(module spider --color=never -s -t -S --no-indepth -o 'alias:indesym' (commandline -ct) 2>&1)"
-complete -c module -n '__fish_module_use_list' -f -a "(module list --color=never -s -t -o '' 2>&1)"
-complete -c module -n '__fish_module_use_initlist' -f -a "(module initlist --color=never -s 2>&1 | sed '\
-   / loads modules:\$/d;')"
-complete -c module -n '__fish_module_use_savelist' -f -a "(module savelist --color=never -s -t 2>&1 | sed '\
-   /No named collection\.\$/d; \
-   /Named collection list\$/d; \
-   /:\$/d; \
-   /:ERROR:/d;')"
-complete -c module -n '__fish_module_use_stashlist' -f -a "(module stashlist --color=never -s -t 2>&1 | sed '\
-   /No stash collection\.\$/d; \
-   /Stash collection list\$/d; \
-   /:\$/d; \
-   /:ERROR:/d;')"
-complete -c module -n '__fish_module_use_config' -f -a "--dump-state --reset abort_on_error advanced_version_spec auto_handling avail_indepth avail_output avail_terse_output cache_buffer_bytes cache_expiry_secs collection_pin_version collection_pin_tag collection_target color colors conflict_unload contact domainname editor extended_default extra_siteconfig hide_auto_loaded home icase ignore_cache ignore_user_rc implicit_default implicit_requirement init_envvars info_extension linked_envvars list_output list_terse_output locked_configs logged_events logger mcookie_check mcookie_version_check ml nearly_forbidden_days non_exportable_tags pager paginate path_entry_reorder protected_envvars quarantine_support rcfile redirect_output require_via reset_target_state run_quarantine search_match set_shell_startup shells_with_ksh_fpath silent_shell_debug source_cache spider_indepth spider_output spider_terse_output sticky_purge tag_abbrev tag_color_name tcl_linter term_background term_width unique_name_loaded unload_match_order variant_shortcut verbosity wa_277"
+function __fish_ml_avail --description 'Test if currently completing the first argument'
+   set cmd_args (commandline -b | string split ' ' --no-empty -- $cmd_args)
+   if test (count $cmd_args ) -le 2
+      return 0
+   end
+   return 1 
+end 
 
-complete -f -n '__fish_module_no_subcommand' -c module -a 'help' --description 'Print this or modulefile(s) help info'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'avail' --description 'List all or matching available modules'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'spider' --description 'Scan all modulepaths and list all or matching available modules'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'is-avail' --description 'Is any of the modulefile(s) available'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'add load' --description 'Load modulefile(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'add-any load-any' --description 'Load first available modulefile in list'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'try-add try-load' --description 'Attempt to load modulefile(s), no complain'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'rm remove del unload' --description 'Remove modulefile(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'swap switch' --description 'Unload mod1 and load mod2'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'show display' --description 'Display information about modulefile(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'list' --description 'List loaded modules'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'is-loaded' --description 'Test if any of the modulefile(s) are loaded'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'info-loaded' --description 'Get full name of matching loaded module(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'aliases' --description 'List all module aliases'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'use' --description 'Add dir(s) to MODULEPATH variable'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'unuse' --description 'Remove dir(s) from MODULEPATH variable'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'is-used' --description 'Is any of the dir(s) enabled in MODULEPATH'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'refresh' --description 'Refresh volatile components of loaded modulefiles'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'reload update' --description 'Unload then load all loaded modulefiles'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'purge' --description 'Unload all loaded modulefiles'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'source' --description 'Execute scriptfile(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'whatis' --description 'Print whatis information of modulefile(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'apropos keyword search' --description 'Search all name and whatis containing str'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'test' --description 'Test modulefile(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'save' --description 'Save current module list to collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'restore' --description 'Restore module list from collection or file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'saverm' --description 'Remove saved collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'disable' --description 'Remove saved collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'saveshow' --description 'Display information about collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'describe' --description 'Display information about collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'savelist' --description 'List all saved collections'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'is-saved' --description 'Test if any of the collection(s) exists'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'initadd' --description 'Add modulefile to shell init file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'initprepend' --description 'Add to beginning of list in init file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'initrm' --description 'Remove modulefile from shell init file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'initswitch' --description 'Switch mod1 with mod2 from init file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'initlist' --description 'List all modules loaded from init file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'initclear' --description 'Clear all modulefiles from init file'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'path' --description 'Print modulefile path'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'paths' --description 'Print path of matching available modules'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'append-path' --description 'Append value to environment variable'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'prepend-path' --description 'Prepend value to environment variable'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'remove-path' --description 'Remove value from environment variable'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'clear' --description 'Reset Modules-specific runtime information'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'config' --description 'Display or set Modules configuration'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'sh-to-mod' --description 'Make modulefile from script env changes'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'edit' --description 'Open modulefile in editor'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'state' --description 'Display Modules state'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'lint' --description 'Check syntax of modulefile'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'mod-to-sh' --description 'Make shell code from modulefile env changes'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'reset' --description 'Restore initial environment'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'stash' --description 'Save current environment and reset'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'stashclear' --description 'Remove all stash collections'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'stashlist' --description 'List all stash collections'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'stashpop' --description 'Restore then remove stash collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'stashrm' --description 'Remove stash collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'stashshow' --description 'Display information about stash collection'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'cachebuild' --description 'Create cache file for modulepath(s)'
-complete -f -n '__fish_module_no_subcommand' -c module -a 'cacheclear' --description 'Delete cache file in enabled modulepath(s)'
+set commands module ml
 
-complete -c module -s V -l version --description 'Module version'
-complete -c module -l dumpname --description 'Module implementation name'
-complete -c module -s T -l trace --description 'Enable trace and debug messages'
-complete -c module -s D -l debug --description 'Enable debug messages'
-complete -c module -s v -l verbose --description 'Enable verbose messages'
-complete -c module -s s -l silent --description 'Turn off error, warning and informational messages'
-complete -c module -s i -l icase --description 'Case insensitive match'
-complete -c module -s t -l terse --description 'Display output in terse format'
-complete -c module -s l -l long --description 'Display output in long format'
-complete -c module -s j -l json --description 'Display output in JSON format'
-complete -c module -s o -l output --description 'Define elements to output in addition to module names'
-complete -c module -l output= --description 'Define elements to output in addition to module names'
-complete -c module -l tag --description 'Apply tag to loading module'
-complete -c module -l tag= --description 'Apply tag to loading module'
-complete -c module -s a -l all --description 'Include hidden modules in search'
-complete -c module -s d -l default --description 'Only show default versions available'
-complete -c module -s L -l latest --description 'Only show latest versions available'
-complete -c module -s S -l starts-with --description 'Search modules whose name begins with query string'
-complete -c module -s C -l contains --description 'Search modules whose name contains query string'
-complete -c module -l indepth --description 'Perform recursive avail search'
-complete -c module -l no-indepth --description 'Perform non-recursive avail search'
-complete -c module -s p -l paginate --description 'Pipe mesg output into a pager if stream attached to terminal'
-complete -c module -s P -l no-pager --description 'Do not pipe message output into a pager'
-complete -c module -l auto --description 'Enable automated module handling mode'
-complete -c module -l no-auto --description 'Disable automated module handling mode'
-complete -c module -s f -l force --description 'By-pass dependency consistency or confirmation dialog'
-complete -c module -l color --description 'Colorize the output'
-complete -c module -l color= --description 'Colorize the output'
-complete -c module -s w -l width --description 'Set output width'
-complete -c module -l width= --description 'Set output width'
-complete -c module -l ignore-cache --description 'Ignore module cache'
-complete -c module -l ignore-user-rc --description 'Skip evaluation of user-specific module rc file'
+
+complete -c ml -n '__fish_ml_avail' -f -a "(module avail --color=never -s -t -S --no-indepth -o 'alias:indesym' (commandline -ct) 2>&1)" 
+
+for command in $commands 
+
+   complete -c $command -n '__fish_module_use_avail' -f -a "(module avail --color=never -s -t -S --no-indepth -o 'alias:indesym' (commandline -ct) 2>&1)"
+   complete -c $command -n '__fish_module_use_spider' -f -a "(module spider --color=never -s -t -S --no-indepth -o 'alias:indesym' (commandline -ct) 2>&1)"
+   complete -c $command -n '__fish_module_use_list' -f -a "(module list --color=never -s -t -o '' 2>&1)"
+   complete -c $command -n '__fish_module_use_initlist' -f -a "(module initlist --color=never -s 2>&1 | sed '\
+      / loads modules:\$/d;')"
+   complete -c $command -n '__fish_module_use_savelist' -f -a "(module savelist --color=never -s -t 2>&1 | sed '\
+      /No named collection\.\$/d; \
+      /Named collection list\$/d; \
+      /:\$/d; \
+      /:ERROR:/d;')"
+   complete -c $command -n '__fish_module_use_stashlist' -f -a "(module stashlist --color=never -s -t 2>&1 | sed '\
+      /No stash collection\.\$/d; \
+      /Stash collection list\$/d; \
+      /:\$/d; \
+      /:ERROR:/d;')"
+   complete -c $command -n '__fish_module_use_config' -f -a "--dump-state --reset abort_on_error advanced_version_spec auto_handling avail_indepth avail_output avail_terse_output cache_buffer_bytes cache_expiry_secs collection_pin_version collection_pin_tag collection_target color colors conflict_unload contact domainname editor extended_default extra_siteconfig hide_auto_loaded home icase ignore_cache ignore_user_rc implicit_default implicit_requirement init_envvars info_extension linked_envvars list_output list_terse_output locked_configs logged_events logger mcookie_check mcookie_version_check ml nearly_forbidden_days non_exportable_tags pager paginate path_entry_reorder protected_envvars quarantine_support rcfile redirect_output require_via reset_target_state run_quarantine search_match set_shell_startup shells_with_ksh_fpath silent_shell_debug source_cache spider_indepth spider_output spider_terse_output sticky_purge tag_abbrev tag_color_name tcl_linter term_background term_width unique_name_loaded unload_match_order variant_shortcut verbosity wa_277"
+   
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'help' --description 'Print this or modulefile(s) help info'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'avail' --description 'List all or matching available modules'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'spider' --description 'Scan all modulepaths and list all or matching available modules'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'is-avail' --description 'Is any of the modulefile(s) available'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'add load' --description 'Load modulefile(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'add-any load-any' --description 'Load first available modulefile in list'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'try-add try-load' --description 'Attempt to load modulefile(s), no complain'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'rm remove del unload' --description 'Remove modulefile(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'swap switch' --description 'Unload mod1 and load mod2'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'show display' --description 'Display information about modulefile(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'list' --description 'List loaded modules'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'is-loaded' --description 'Test if any of the modulefile(s) are loaded'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'info-loaded' --description 'Get full name of matching loaded module(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'aliases' --description 'List all $command aliases'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'use' --description 'Add dir(s) to MODULEPATH variable'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'unuse' --description 'Remove dir(s) from MODULEPATH variable'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'is-used' --description 'Is any of the dir(s) enabled in MODULEPATH'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'refresh' --description 'Refresh volatile components of loaded modulefiles'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'reload update' --description 'Unload then load all loaded modulefiles'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'purge' --description 'Unload all loaded modulefiles'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'source' --description 'Execute scriptfile(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'whatis' --description 'Print whatis information of modulefile(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'apropos keyword search' --description 'Search all name and whatis containing str'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'test' --description 'Test modulefile(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'save' --description 'Save current $command list to collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'restore' --description 'Restore $command list from collection or file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'saverm' --description 'Remove saved collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'disable' --description 'Remove saved collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'saveshow' --description 'Display information about collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'describe' --description 'Display information about collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'savelist' --description 'List all saved collections'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'is-saved' --description 'Test if any of the collection(s) exists'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'initadd' --description 'Add modulefile to shell init file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'initprepend' --description 'Add to beginning of list in init file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'initrm' --description 'Remove modulefile from shell init file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'initswitch' --description 'Switch mod1 with mod2 from init file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'initlist' --description 'List all modules loaded from init file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'initclear' --description 'Clear all modulefiles from init file'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'path' --description 'Print modulefile path'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'paths' --description 'Print path of matching available modules'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'append-path' --description 'Append value to environment variable'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'prepend-path' --description 'Prepend value to environment variable'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'remove-path' --description 'Remove value from environment variable'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'clear' --description 'Reset Modules-specific runtime information'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'config' --description 'Display or set Modules configuration'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'sh-to-mod' --description 'Make modulefile from script env changes'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'edit' --description 'Open modulefile in editor'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'state' --description 'Display Modules state'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'lint' --description 'Check syntax of modulefile'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'mod-to-sh' --description 'Make shell code from modulefile env changes'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'reset' --description 'Restore initial environment'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'stash' --description 'Save current environment and reset'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'stashclear' --description 'Remove all stash collections'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'stashlist' --description 'List all stash collections'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'stashpop' --description 'Restore then remove stash collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'stashrm' --description 'Remove stash collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'stashshow' --description 'Display information about stash collection'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'cachebuild' --description 'Create cache file for modulepath(s)'
+   complete -f -n '__fish_module_no_subcommand' -c $command -a 'cacheclear' --description 'Delete cache file in enabled modulepath(s)'
+   
+   complete -c $command -s V -l version --description 'Module version'
+   complete -c $command -l dumpname --description 'Module implementation name'
+   complete -c $command -s T -l trace --description 'Enable trace and debug messages'
+   complete -c $command -s D -l debug --description 'Enable debug messages'
+   complete -c $command -s v -l verbose --description 'Enable verbose messages'
+   complete -c $command -s s -l silent --description 'Turn off error, warning and informational messages'
+   complete -c $command -s i -l icase --description 'Case insensitive match'
+   complete -c $command -s t -l terse --description 'Display output in terse format'
+   complete -c $command -s l -l long --description 'Display output in long format'
+   complete -c $command -s j -l json --description 'Display output in JSON format'
+   complete -c $command -s o -l output --description 'Define elements to output in addition to $command names'
+   complete -c $command -l output= --description 'Define elements to output in addition to $command names'
+   complete -c $command -l tag --description 'Apply tag to loading module'
+   complete -c $command -l tag= --description 'Apply tag to loading module'
+   complete -c $command -s a -l all --description 'Include hidden modules in search'
+   complete -c $command -s d -l default --description 'Only show default versions available'
+   complete -c $command -s L -l latest --description 'Only show latest versions available'
+   complete -c $command -s S -l starts-with --description 'Search modules whose name begins with query string'
+   complete -c $command -s C -l contains --description 'Search modules whose name contains query string'
+   complete -c $command -l indepth --description 'Perform recursive avail search'
+   complete -c $command -l no-indepth --description 'Perform non-recursive avail search'
+   complete -c $command -s p -l paginate --description 'Pipe mesg output into a pager if stream attached to terminal'
+   complete -c $command -s P -l no-pager --description 'Do not pipe message output into a pager'
+   complete -c $command -l auto --description 'Enable automated $command handling mode'
+   complete -c $command -l no-auto --description 'Disable automated $command handling mode'
+   complete -c $command -s f -l force --description 'By-pass dependency consistency or confirmation dialog'
+   complete -c $command -l color --description 'Colorize the output'
+   complete -c $command -l color= --description 'Colorize the output'
+   complete -c $command -s w -l width --description 'Set output width'
+   complete -c $command -l width= --description 'Set output width'
+   complete -c $command -l ignore-cache --description 'Ignore $command cache'
+   complete -c $command -l ignore-user-rc --description 'Skip evaluation of user-specific $command rc file'
+end 


### PR DESCRIPTION
Resolves issue #417.

Added completion for fish shell. 
No additional files were needed.

`ml` command now supports all `module` command options and also adds the `module available` list as first complete option. 